### PR TITLE
Disable falco k8s audit logging webserver.

### DIFF
--- a/analysis/customrules.yaml
+++ b/analysis/customrules.yaml
@@ -25,6 +25,8 @@ falco:
   outputs:
     rate: 10
     maxBurst: 10000
+  webserver:
+    enabled: false
 customRules:
   rules-custom.yaml: |-
     - list: allowed_files


### PR DESCRIPTION
This is not necessary and also recommended in
https://github.com/falcosecurity/falco/issues/1403.