### PR TITLE
Catch more file accesses.

### DIFF
--- a/analysis/customrules.yaml
+++ b/analysis/customrules.yaml
@@ -27,30 +27,54 @@ falco:
     maxBurst: 10000
   webserver:
     enabled: false
+extraArgs:
+  - "-A"  # https://falco.org/docs/rules/#ignored-system-calls
 customRules:
   rules-custom.yaml: |-
     - list: allowed_files
       items: [/etc/ld.so.cache, /etc/hosts, /usr/lib/ssl/openssl.cnf, /etc/nsswitch.conf, /etc/resolv.conf]
-    - rule: Unexpected file access
-      desc: Detect file access outside the workingdir
+    - macro: stat_file
+      condition: evt.type in (access, stat, stat64, lstat, lstat64)
+    - macro: open_file
+      condition: (evt.type in (open, openat) and evt.is_open_read=true)
+    - rule: Unexpected file stat
+      desc: Detect file stat outside the workingdir
       condition: >
-        (open_read and 
-         not fd.name startswith /app/ and
-         not fd.name startswith /tmp/ and
-         not fd.name startswith /usr/local/lib/ and
-         not fd.name startswith /usr/lib/ and
-         not fd.name startswith /lib/ and
-         not fd.name startswith /proc/ and
-         not fd.name startswith /usr/lib/locale/ and
-         not fd.name startswith /usr/include/c++ and
-         not fd.name startswith /run/containerd/ and
-         not fd.name startswith /usr/local/bundle/ and
-         not fd.name startswith /usr/local/include/ruby-3.0.0/ and
-         not fd.name in (allowed_files) and
+        (stat_file and
+         not evt.arg.path startswith /app and
+         not evt.arg.path startswith /tmp and
+         not evt.arg.path startswith /usr/local and
+         not evt.arg.path startswith /usr/lib and
+         not evt.arg.path startswith /usr/share and
+         not evt.arg.path startswith /lib and
+         not evt.arg.path startswith /proc and
+         not evt.arg.path startswith /usr/include/c++ and
+         not evt.arg.path startswith /run/containerd and
+         not evt.arg.path in (allowed_files) and
          container and
          k8s.ns.name="default" and
          k8s.pod.label.install="1")
-      output: unexpected file access (command=%proc.cmdline fd=%fd.name user=%user.name pod=%k8s.pod.name labels=%k8s.pod.labels)
+      output: unexpected file stat (command=%proc.cmdline type=%evt.type fd=%evt.arg.path user=%user.name pod=%k8s.pod.name labels=%k8s.pod.labels)
+      priority: CRITICAL
+
+    - rule: Unexpected file access
+      desc: Detect file access outside the workingdir
+      condition: >
+        (open_file and
+         not evt.arg.name startswith /app and
+         not evt.arg.name startswith /tmp and
+         not evt.arg.name startswith /usr/local and
+         not evt.arg.name startswith /usr/lib and
+         not evt.arg.name startswith /usr/share and
+         not evt.arg.name startswith /lib and
+         not evt.arg.name startswith /proc and
+         not evt.arg.name startswith /usr/include/c++ and
+         not evt.arg.name startswith /run/containerd and
+         not evt.arg.name in (allowed_files) and
+         container and
+         k8s.ns.name="default" and
+         k8s.pod.label.install="1")
+      output: unexpected file access (command=%proc.cmdline type=%evt.type fd=%evt.arg.name user=%user.name pod=%k8s.pod.name labels=%k8s.pod.labels)
       priority: CRITICAL
 
     - rule: Network connection

--- a/analysis/customrules.yaml
+++ b/analysis/customrules.yaml
@@ -36,7 +36,7 @@ customRules:
     - macro: stat_file
       condition: evt.type in (access, stat, stat64, lstat, lstat64)
     - macro: open_file
-      condition: (evt.type in (open, openat) and evt.is_open_read=true)
+      condition: evt.type in (open, openat)
     - rule: Unexpected file stat
       desc: Detect file stat outside the workingdir
       condition: >

--- a/analysis/customrules.yaml
+++ b/analysis/customrules.yaml
@@ -34,15 +34,14 @@ customRules:
     - list: allowed_files
       items: [/etc/ld.so.cache, /etc/hosts, /usr/lib/ssl/openssl.cnf, /etc/nsswitch.conf, /etc/resolv.conf]
     - macro: stat_file
-      condition: evt.type in (access, stat, stat64, lstat, lstat64)
+      condition: evt.type in (stat, stat64, lstat, lstat64) and evt.arg.path!=""
     - macro: open_file
-      condition: evt.type in (open, openat)
+      condition: evt.type in (open, openat) and evt.arg.name!=""
     - rule: Unexpected file stat
       desc: Detect file stat outside the workingdir
       condition: >
         (stat_file and
          not evt.arg.path startswith /app and
-         not evt.arg.path startswith /tmp and
          not evt.arg.path startswith /usr/local and
          not evt.arg.path startswith /usr/lib and
          not evt.arg.path startswith /usr/share and
@@ -61,7 +60,6 @@ customRules:
       condition: >
         (open_file and
          not evt.arg.name startswith /app and
-         not evt.arg.name startswith /tmp and
          not evt.arg.name startswith /usr/local and
          not evt.arg.name startswith /usr/lib and
          not evt.arg.name startswith /usr/share and

--- a/analysis/customrules.yaml
+++ b/analysis/customrules.yaml
@@ -47,7 +47,6 @@ customRules:
          not evt.arg.path startswith /usr/lib and
          not evt.arg.path startswith /usr/share and
          not evt.arg.path startswith /lib and
-         not evt.arg.path startswith /proc and
          not evt.arg.path startswith /usr/include/c++ and
          not evt.arg.path startswith /run/containerd and
          not evt.arg.path in (allowed_files) and
@@ -67,7 +66,6 @@ customRules:
          not evt.arg.name startswith /usr/lib and
          not evt.arg.name startswith /usr/share and
          not evt.arg.name startswith /lib and
-         not evt.arg.name startswith /proc and
          not evt.arg.name startswith /usr/include/c++ and
          not evt.arg.name startswith /run/containerd and
          not evt.arg.name in (allowed_files) and

--- a/analysis/main.go
+++ b/analysis/main.go
@@ -35,7 +35,8 @@ type OutputFields struct {
 	Pod            string `json:"k8s.pod.name"`
 	CmdLine        string `json:"proc.cmdline"`
 	IP             string `json:"fd.sip"`
-	Path           string `json:"fd.name"`
+	Path           string `json:"evt.arg.path"`
+	Name           string `json:"evt.arg.name"`
 	Labels         string `json:"k8s.pod.labels"`
 }
 
@@ -131,7 +132,7 @@ func falcoHandler(w http.ResponseWriter, r *http.Request) {
 		info := getPodInfo(pod)
 		switch output.Rule {
 		case "Unexpected file access":
-			info.Files[output.OutputFields.Path] = true
+			info.Files[output.OutputFields.Name] = true
 		case "Unexpected file stat":
 			info.Files[output.OutputFields.Path] = true
 		case "Network connection":
@@ -167,7 +168,9 @@ func finalizePod(podName string) func() {
 
 		d := data{}
 		for f, _ := range info.Files {
-			d.Files = append(d.Files, f)
+			if f != "" {
+				d.Files = append(d.Files, f)
+			}
 		}
 		for ip, _ := range info.IPs {
 			d.IPs = append(d.IPs, ip)

--- a/analysis/main.go
+++ b/analysis/main.go
@@ -132,6 +132,8 @@ func falcoHandler(w http.ResponseWriter, r *http.Request) {
 		switch output.Rule {
 		case "Unexpected file access":
 			info.Files[output.OutputFields.Path] = true
+		case "Unexpected file stat":
+			info.Files[output.OutputFields.Path] = true
 		case "Network connection":
 			info.IPs[output.OutputFields.IP] = true
 		default:

--- a/analysis/main.go
+++ b/analysis/main.go
@@ -168,9 +168,7 @@ func finalizePod(podName string) func() {
 
 		d := data{}
 		for f, _ := range info.Files {
-			if f != "" {
-				d.Files = append(d.Files, f)
-			}
+			d.Files = append(d.Files, f)
 		}
 		for ip, _ := range info.IPs {
 			d.IPs = append(d.IPs, ip)


### PR DESCRIPTION
- Record opening paths even if they fail.
- Record stat syscalls on filepaths.
- Also add/simplify some exclusions.
- Remove /proc, /tmp from exclusions

For #40.