### PR TITLE
Use slim base images for the language analysis images.

### DIFF
--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -12,5 +12,5 @@ rm -rf analysis/analysis
 cp -r ../analysis analysis/
 
 for image in "${IMAGES[@]}"; do
-  docker build -t $REGISTRY/$image $image
+  docker build --squash -t $REGISTRY/$image $image
 done

--- a/build/node/Dockerfile
+++ b/build/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.1.0@sha256:2e0fc91aaa6081b9d871b81a01f1c80fda83071e5d7a32ec17e2ac346fa8f008
+FROM node:16.1.0-slim@sha256:972548af5d81a09288fe9bb1b7291ff0c4e4e41e4b2e5f5ca80a80fc363e62f3
 
 COPY analyze.js /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.js

--- a/build/python/Dockerfile
+++ b/build/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5@sha256:0813df59b3d73a13fc581fd416d7733a2de6540d7e3f7633a1a9aabf9b201548
+FROM python:3.9.5-slim@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049facd2703e57892447
 
 COPY analyze.py /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.py

--- a/build/ruby/Dockerfile
+++ b/build/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.1@sha256:091ee4779c0d90155b6d1a317855ce64714e6485f9db4413c812ddd112df7dc7
+FROM ruby:3.0.1-slim@sha256:3c0f26c0071ccdd6b5ab0c3ed615cd1f0cfd30b0039d1d5d7c2e70c66441e09a
 
 COPY analyze.rb /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.rb


### PR DESCRIPTION
Also docker build --squash.

This reduces the size of images to 1/8 their previous size and speeds up
analysis by a significant amount.