### PR TITLE
Various fixes.

### DIFF
--- a/analysis/npm.go
+++ b/analysis/npm.go
@@ -31,7 +31,7 @@ func getNPMLatest(pkg string) string {
 }
 
 var NPMPackageManager = PkgManager{
-	Image: "gcr.io/ossf-malware-analysis/node:flat",
+	Image: "gcr.io/ossf-malware-analysis/node",
 	CommandFmt: func(pkg, ver string) string {
 		return fmt.Sprintf("analyze.js %s@%s", pkg, ver)
 	},

--- a/analysis/pypi.go
+++ b/analysis/pypi.go
@@ -31,7 +31,7 @@ func getPyPILatest(pkg string) string {
 }
 
 var PyPIPackageManager = PkgManager{
-	Image: "gcr.io/ossf-malware-analysis/python:flat",
+	Image: "gcr.io/ossf-malware-analysis/python",
 	CommandFmt: func(pkg, ver string) string {
 		return fmt.Sprintf("analyze.py %s==%s", pkg, ver)
 	},

--- a/analysis/rubygems.go
+++ b/analysis/rubygems.go
@@ -29,7 +29,7 @@ func getRubyGemsLatest(pkg string) string {
 }
 
 var RubyGemsPackageManager = PkgManager{
-	Image: "gcr.io/ossf-malware-analysis/ruby:flat",
+	Image: "gcr.io/ossf-malware-analysis/ruby",
 	CommandFmt: func(pkg, ver string) string {
 		return fmt.Sprintf("analyze.rb %s %s", pkg, ver)
 	},

--- a/build/analysis/Dockerfile
+++ b/build/analysis/Dockerfile
@@ -29,6 +29,6 @@ COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
 
 # Cache analysis images.
-RUN podman pull gcr.io/ossf-malware-analysis/node:flat && \
-    podman pull gcr.io/ossf-malware-analysis/python:flat && \
-    podman pull gcr.io/ossf-malware-analysis/ruby:flat
+RUN podman pull gcr.io/ossf-malware-analysis/node && \
+    podman pull gcr.io/ossf-malware-analysis/python && \
+    podman pull gcr.io/ossf-malware-analysis/ruby

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -9,14 +9,7 @@ IMAGES=(
 
 for image in "${IMAGES[@]}"; do
   docker build --squash -t $REGISTRY/$image $image
-
-  # Flatten the image.
-  container=$(docker create $REGISTRY/$image)
-  docker export $container | docker import - $REGISTRY/$image:flat
-  docker rm $container
-
   docker push $REGISTRY/$image
-  docker push $REGISTRY/$image:flat
 done
 
 rm -rf analysis/analysis

--- a/build/node/Dockerfile
+++ b/build/node/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:16.1.0-slim@sha256:972548af5d81a09288fe9bb1b7291ff0c4e4e41e4b2e5f5ca80a80fc363e62f3
+FROM node:16.1.0-slim@sha256:972548af5d81a09288fe9bb1b7291ff0c4e4e41e4b2e5f5ca80a80fc363e62f3 as image
 
 COPY analyze.js /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.js
-
-ENV NODE_PATH /app/node_modules
 RUN mkdir -p /app
+
+FROM scratch
+COPY --from=image / /
+ENV NODE_PATH /app/node_modules
 WORKDIR /app

--- a/build/node/analyze.js
+++ b/build/node/analyze.js
@@ -3,7 +3,7 @@
 const { spawnSync } = require('child_process');
 
 if (process.argv.length < 3) {
-  console.log(`Usage: ${process.argv[0]} ${process.argv[1]} pkg@version`)
+  console.log(`Usage: ${process.argv[0]} ${process.argv[1]} pkg@version`);
   process.exit(1);
 }
 
@@ -12,16 +12,23 @@ if (result.status != 0) {
   throw 'Failed to init npm';
 }
 
-const pkgAndVersion = process.argv[2]
-result = spawnSync('npm', ['install', pkgAndVersion], { stdio: 'inherit' });
-if (result.status != 0) {
-  throw 'Failed to install';
+const pkgAndVersion = process.argv[2];
+result = spawnSync('npm', ['install', pkgAndVersion], { stdio: 'pipe', encoding: 'utf8' });
+console.log(result.stdout + result.stderr);
+
+if (result.status == 0) {
+  console.log('Install succeeded.');
+} else {
+  if (result.stderr.includes('is not in the npm registry.')) {
+    process.exit(0);
+  }
+  console.log('Install failed.');
+  process.exit(1);
 }
 
-const pkg = pkgAndVersion.split('@')[0]
+const pkg = pkgAndVersion.split('@')[0];
 try {
   require(pkg);
 } catch (e) {
   console.log(`Failed to import ${pkg}: ${e}`);
 }
-

--- a/build/python/Dockerfile
+++ b/build/python/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.9.5-slim@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049facd2703e57892447
+FROM python:3.9.5-slim@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049facd2703e57892447 as image
 
 COPY analyze.py /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.py
-
 RUN mkdir -p /app
+
+FROM scratch
+COPY --from=image / /
 WORKDIR /app

--- a/build/python/analyze.py
+++ b/build/python/analyze.py
@@ -10,7 +10,20 @@ PY_EXTENSION = '.py'
 
 def pip_install(package):
     """Pip install."""
-    subprocess.check_call((sys.executable, '-m', 'pip', 'install', package))
+    try:
+      output = subprocess.check_output(
+          (sys.executable, '-m', 'pip', 'install', package),
+          stderr=subprocess.STDOUT)
+      print('Install succeeded:')
+      print(output.decode())
+    except subprocess.CalledProcessError as e:
+      print('Failed to install:')
+      print(e.output.decode())
+      if b'No matching distribution' in e.output:
+          sys.exit(0)
+
+      # Some other unknown error.
+      raise
 
 
 def path_to_import(path):
@@ -41,7 +54,7 @@ def analyze(package):
 
 def main():
     if len(sys.argv) != 2:
-      raise ValueError(f'Usage: {sys.argv[0]} package_name[==version]')
+        raise ValueError(f'Usage: {sys.argv[0]} package_name[==version]')
 
     package_with_version = sys.argv[1]
     pip_install(package_with_version)

--- a/build/ruby/Dockerfile
+++ b/build/ruby/Dockerfile
@@ -1,7 +1,9 @@
-FROM ruby:3.0.1-slim@sha256:3c0f26c0071ccdd6b5ab0c3ed615cd1f0cfd30b0039d1d5d7c2e70c66441e09a
+FROM ruby:3.0.1-slim@sha256:3c0f26c0071ccdd6b5ab0c3ed615cd1f0cfd30b0039d1d5d7c2e70c66441e09a as image
 
 COPY analyze.rb /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.rb
-
 RUN mkdir -p /app
+
+FROM scratch
+COPY --from=image / /
 WORKDIR /app

--- a/build/ruby/analyze.rb
+++ b/build/ruby/analyze.rb
@@ -1,7 +1,30 @@
 #!/usr/bin/env ruby
 #
 require 'find'
+require 'open3'
 require 'pathname'
+
+def install(package, version)
+  cmd = "gem install #{package}"
+  if version
+    cmd += " -v #{version}"
+  end
+
+  output, status = Open3.capture2e(cmd)
+  puts output
+
+  if status.success?
+    puts "Install succeeded."
+    return
+  end
+
+  puts "Install failed."
+  if output.include? "Could not find a valid gem"
+    exit 0
+  end
+
+  exit 1
+end
 
 if ARGV.length < 1
   puts "Usage: #{$0} package version"
@@ -11,15 +34,7 @@ end
 package = ARGV.shift
 version = ARGV.shift
 
-cmd = "gem install #{package}"
-if version
-  cmd += " -v #{version}"
-end
-
-if not system(cmd)
-  exit 1
-end
-
+install(package, version)
 spec = Gem::Specification.find_by_name(package)
 
 spec.require_paths.each do |require_path|


### PR DESCRIPTION
- Squash analysis images by default in the Dockerfiles. The previous method
  didn't retain WORKDIR and env vars which caused issues.

- Exit cleanly if the package to be analysed is not found to avoid
  unnecessary retries.

- More cleanly handle an harmless error message from gVisor.