### PR TITLE
Write analysis results to firestore.

### DIFF
--- a/analysis/cmd/fillindexes.go
+++ b/analysis/cmd/fillindexes.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/ossf/package-analysis/analysis"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/gcsblob"
+)
+
+var (
+	bucket       = flag.String("bucket", "", "bucket")
+	docstorePath = flag.String("docstore", "", "docstore path to write to")
+)
+
+const (
+	numWorkers = 128
+)
+
+func main() {
+	flag.Parse()
+	if *bucket == "" || *docstorePath == "" {
+		flag.Usage()
+		return
+	}
+
+	ctx := context.Background()
+	bkt, err := blob.OpenBucket(ctx, *bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bkt.Close()
+
+	queue := make(chan string, numWorkers)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for key := range queue {
+				fmt.Println(key)
+				data, err := bkt.ReadAll(ctx, key)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				var results analysis.AnalysisResult
+				err = json.Unmarshal(data, &results)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				analysis.WriteResultsToDocstore(ctx, *docstorePath, &results)
+			}
+			wg.Done()
+		}()
+	}
+
+	it := bkt.List(nil)
+	for {
+		obj, err := it.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !strings.HasSuffix(obj.Key, ".json") {
+			continue
+		}
+
+		queue <- obj.Key
+	}
+	close(queue)
+	wg.Wait()
+}

--- a/analysis/config/deployment.yaml
+++ b/analysis/config/deployment.yaml
@@ -24,6 +24,8 @@ spec:
           value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results
+        - name: OSSMALWARE_DOCSTORE_URL
+          value: firestore://projects/ossf-malware-analysis/databases/(default)/documents/analysis?name_field=ID
         securityContext:
           privileged: true
         resources:

--- a/analysis/config/deployment.yaml
+++ b/analysis/config/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results
         - name: OSSMALWARE_DOCSTORE_URL
-          value: firestore://projects/ossf-malware-analysis/databases/(default)/documents/analysis?name_field=ID
+          value: firestore://projects/ossf-malware-analysis/databases/(default)/documents/
         securityContext:
           privileged: true
         resources:

--- a/analysis/go.sum
+++ b/analysis/go.sum
@@ -30,6 +30,7 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/firestore v1.5.0 h1:4qNItsmc4GP6UOZPGemmHY4ZfPofVhcaKXsYw9wm9oA=
 cloud.google.com/go/firestore v1.5.0/go.mod h1:c4nNYR1qdq7eaZ+jSc5fonrQN2k3M7sWATcYTiakjEo=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=


### PR DESCRIPTION
Firestore entities will serve as an index for the JSON stored on GCS.

This will be used to serve interactive queries/searches from a dashboard.