### PR TITLE
Add retries with backoff for scheduler/worker

### DIFF
--- a/examples/e2e/docker-compose.yml
+++ b/examples/e2e/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       retries: 3
 
   analysis:
-    restart: "on-failure"
     image: gcr.io/ossf-malware-analysis/analysis:latest
     privileged: true
     entrypoint: "/usr/local/bin/worker"
@@ -56,8 +55,8 @@ services:
       AWS_REGION: dummy_region
     depends_on:
       - kafka
+
   scheduler:
-    restart: "on-failure"
     image: gcr.io/ossf-malware-analysis/scheduler:latest
     entrypoint: "/usr/local/bin/scheduler"
     depends_on:


### PR DESCRIPTION
Add retries to reduce hard failures in situations where the pubsub endpoint isn't ready or has a small outage. 

Currently the retry configurations are hard coded as constants, we could look at breaking these out into environment variables if the default is not sufficient for all use cases.

Resolves #81
Resolves #82