### PR TITLE
Add github action for build_docker on merge

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,25 @@
+name: "Build docker"
+
+on: [pull_request, push]
+
+jobs:
+  build_docker:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: setup-go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.15.5'
+
+    - name: Enable docker experimental
+      run: |
+        echo $'{"experimental": true}' | sudo dd status=none of=/etc/docker/daemon.json
+        sudo service docker restart
+        docker version -f '{{.Server.Experimental}}'
+
+    - name: build_docker
+      run: NOPUSH=true NO_PODMAN_PULL=1 ./build_docker.sh
+      working-directory: build

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get upgrade -y && \
 
 # Install gVisor.
 RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
-    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases master main" && \
+    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases 20210601 main" && \
     apt-get update && apt-get install -y runsc
 
 # runsc with our own builtin args.

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
 
 # Cache analysis images.
-RUN podman pull gcr.io/ossf-malware-analysis/node && \
-    podman pull gcr.io/ossf-malware-analysis/python && \
-    podman pull gcr.io/ossf-malware-analysis/ruby
+ARG NO_PODMAN_PULL
+RUN test -n "$NO_PODMAN_PULL" || \
+    (podman pull gcr.io/ossf-malware-analysis/node && \
+     podman pull gcr.io/ossf-malware-analysis/python && \
+     podman pull gcr.io/ossf-malware-analysis/ruby)

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -10,7 +10,7 @@ ANALYSIS_IMAGES=(
 )
 
 for image in "${ANALYSIS_IMAGES[@]}"; do
-  docker build --squash -t $REGISTRY/$image $image
+  docker build -t $REGISTRY/$image $image
   [[ "$nopush" == "false" ]]  && docker push $REGISTRY/$image
 done
 
@@ -22,7 +22,7 @@ OTHER_IMAGES=(
 
 for image in "${OTHER_IMAGES[@]}"; do
   pushd ../$image
-  docker build --squash -t $REGISTRY/$image .
+  docker build --build-arg NO_PODMAN_PULL=$NO_PODMAN_PULL -t $REGISTRY/$image .
   [[ "$nopush" == "false" ]] && docker push $REGISTRY/$image
   popd
 done


### PR DESCRIPTION
This allows for docker images to be built and pushed via github actions. Resolves #86

@oliverchang We will need to add the necessary secrets via the repository configuration for pushing to gcr.io 