### PR TITLE
Update package-feeds reference

### DIFF
--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -3,7 +3,7 @@ module github.com/ossf/package-analysis/scheduler
 go 1.15
 
 require (
-	github.com/ossf/package-feeds v0.0.0-20210521141112-9f84198979a6
+	github.com/ossf/package-feeds v0.0.0-20210615142517-0d7adefb4766
 	gocloud.dev v0.23.0
 	gocloud.dev/pubsub/kafkapubsub v0.22.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -309,6 +309,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/ossf/package-analysis v0.0.0-20210525065251-ea8024cf12e7 h1:Ilc+n676GDvXPIOIXJovxd4r6m3Lnyor7csQ4WtaA7I=
 github.com/ossf/package-feeds v0.0.0-20210521141112-9f84198979a6 h1:/8+We9Wj7ratSouzNHBnGQ5boyBrxhQADBseKsiszzE=
 github.com/ossf/package-feeds v0.0.0-20210521141112-9f84198979a6/go.mod h1:O4i4UuYUUZr0tgFEQctzrH/IQCLNKvcr54ZPwK1STZI=
+github.com/ossf/package-feeds v0.0.0-20210615142517-0d7adefb4766 h1:QqSYX79INGeVkVEGkyI9zpo4Vu6huMpCER/XBDiUBA4=
+github.com/ossf/package-feeds v0.0.0-20210615142517-0d7adefb4766/go.mod h1:O4i4UuYUUZr0tgFEQctzrH/IQCLNKvcr54ZPwK1STZI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -14,7 +14,7 @@ import (
 	_ "gocloud.dev/pubsub/kafkapubsub"
 
 	"github.com/ossf/package-analysis/scheduler/proxy"
-	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/pkg/feeds"
 )
 
 const (


### PR DESCRIPTION
This updates the reference to package-feeds following the merge of https://github.com/ossf/package-feeds/pull/137, the feeds sub package has been moved into the pkg subdirectory.