### PR TITLE
Stop caching sandbox images in analysis image.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,5 +21,5 @@ jobs:
         docker version -f '{{.Server.Experimental}}'
 
     - name: build_docker
-      run: NOPUSH=true NO_PODMAN_PULL=1 ./build_docker.sh
+      run: NOPUSH=true ./build_docker.sh
       working-directory: build

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -20,7 +20,7 @@ declare -A CMD_IMAGES=( [analysis]=analyze [scheduler]=scheduler [server]=server
 
 pushd "$BASE_PATH"
 for image in "${!CMD_IMAGES[@]}"; do
-  docker build --build-arg NO_PODMAN_PULL=$NO_PODMAN_PULL -t $REGISTRY/$image -f cmd/${CMD_IMAGES[$image]}/Dockerfile .
+  docker build -t $REGISTRY/$image -f cmd/${CMD_IMAGES[$image]}/Dockerfile .
   [[ "$nopush" == "false" ]] && docker push $REGISTRY/$image
 done
 popd

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -26,10 +26,3 @@ RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
 
 COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
-
-# Cache analysis images.
-ARG NO_PODMAN_PULL
-RUN test -n "$NO_PODMAN_PULL" || \
-    (podman pull gcr.io/ossf-malware-analysis/node && \
-     podman pull gcr.io/ossf-malware-analysis/python && \
-     podman pull gcr.io/ossf-malware-analysis/ruby)

--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: workers-deployment
+  name: workers-set
   labels:
     app: workers
 spec:
+  serviceName: workers
   replicas: 5
   selector:
     matchLabels:
@@ -28,6 +29,9 @@ spec:
           value: firestore://projects/ossf-malware-analysis/databases/(default)/documents/
         securityContext:
           privileged: true
+        volumeMounts:
+          - mountPath: "/var/lib/containers"
+            name: image-storage
         resources:
           requests:
             cpu: 500m
@@ -35,3 +39,13 @@ spec:
           limits:
             cpu: 1
             memory: 1Gi
+  volumeClaimTemplates:
+  - metadata:
+      name: image-storage
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: premium-rwo
+      resources:
+        requests:
+          storage: 30Gi  

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -54,6 +54,12 @@ func podmanPull(image string) error {
 	return cmd.Run()
 }
 
+func podmanPrune() error {
+	args := []string{"image", "prune", "-f"}
+	cmd := exec.Command(podmanBin, args...)
+	return cmd.Run()
+}
+
 func podmanCleanContainers() error {
 	args := []string{"rm", "--all", "--force"}
 	cmd := exec.Command(podmanBin, args...)
@@ -91,6 +97,9 @@ type Sandbox struct {
 // The image supplied will be pulled if it hasn't already been.
 func Init(image string) (*Sandbox, error) {
 	if err := podmanPull(image); err != nil {
+		return nil, err
+	}
+	if err := podmanPrune(); err != nil {
 		return nil, err
 	}
 	return &Sandbox{


### PR DESCRIPTION
This causes various issues (such as compatibility on CI), and presents
scalability issues with larger images.

Instead, pull images on demand and cache them in persistent storage volume
on our workers. Make our workers a StatefulSet instead of Deployment to
support this.

This helps #146.