### PR TITLE
Improve the Sandbox API and have the Analysis know nothing about images.

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
+	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
 const (
@@ -69,7 +70,8 @@ func messageLoop(ctx context.Context, subURL, resultsBucket string) error {
 			"ecosystem", ecosystem,
 			"name", name,
 			"version", version)
-		result := analysis.RunLive(ecosystem, name, version, manager.Image, manager.CommandFmt(name, version))
+		sb := sandbox.New(manager.Image)
+		result := analysis.RunLive(ecosystem, name, version, sb, manager.CommandFmt(name, version))
 
 		if resultsBucket != "" {
 			err = analysis.UploadResults(ctx, resultsBucket, ecosystem+"/"+name, result)

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -51,24 +51,24 @@ const (
 	maxIndexEntries = 10000
 )
 
-func RunLocal(ecosystem, pkgPath, version, image, command string) *AnalysisResult {
-	return run(ecosystem, pkgPath, version, image, command, []string{
+func RunLocal(ecosystem, pkgPath, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
+	return run(ecosystem, pkgPath, version, sb, command, []string{
 		"-v", fmt.Sprintf("%s:%s", pkgPath, pkgPath),
 	})
 }
 
-func RunLive(ecosystem, pkgName, version, image, command string) *AnalysisResult {
-	return run(ecosystem, pkgName, version, image, command, nil)
+func RunLive(ecosystem, pkgName, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
+	return run(ecosystem, pkgName, version, sb, command, nil)
 }
 
-func run(ecosystem, pkgName, version, image, command string, args []string) *AnalysisResult {
+func run(ecosystem, pkgName, version string, sb sandbox.Sandbox, command string, args []string) *AnalysisResult {
 	log.Info("Running analysis",
 		"command", command,
 		"args", args)
 
 	// Init the sandbox
 	log.Debug("Init the sandbox")
-	sb, err := sandbox.Init(image)
+	err := sb.Init()
 	if err != nil {
 		log.Panic("Failed to init sandbox",
 			"error", err)


### PR DESCRIPTION
This also allows us to add a flag (`-nopull`) for disabling image pulling which is useful while developing sandbox images.

For example, to use a local container rather than a remote one the following can be done:
```
$ sudo apt install podman
$ sudo buildah pull docker-daemon:gcr.io/ossf-malware-analysis/node:latest
$ docker run -v /var/lib/containers:/var/lib/containers \
            ...
         gcr.io/ossf-malware-analysis/analysis analyze \
            ...
         -nopull
```