### PR TITLE
Update the sandboxes to prepare them to fully support the new API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ $ docker run --privileged -ti \
 
 ### Local package
 
-To run this on a local package archive (e.g. `/path/to/test.whl`), it needs to
-be mounted into the the container.
+To run this on a local package archive (e.g. `/path/to/test.whl` for a package
+named `test`), it needs to be mounted into the the container.
 
 ```bash
 $ mkdir /tmp/results
@@ -94,7 +94,7 @@ $ docker run --privileged -ti \
     -v /tmp/results:/results \
     -v /path/to/test.whl:/test.whl \
     gcr.io/ossf-malware-analysis/analysis analyze \
-    -local /test.whl -ecosystem pypi \
+    -local /test.whl -package test -ecosystem pypi \
     -upload file:///results/
 ```
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -71,7 +71,7 @@ func messageLoop(ctx context.Context, subURL, resultsBucket string) error {
 			"name", name,
 			"version", version)
 		sb := sandbox.New(manager.Image)
-		result := analysis.RunLive(ecosystem, name, version, sb, manager.Command("all", name, version, ""))
+		result := analysis.Run(ecosystem, name, version, sb, manager.Args("all", name, version, ""))
 
 		if resultsBucket != "" {
 			err = analysis.UploadResults(ctx, resultsBucket, ecosystem+"/"+name, result)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -71,7 +71,7 @@ func messageLoop(ctx context.Context, subURL, resultsBucket string) error {
 			"name", name,
 			"version", version)
 		sb := sandbox.New(manager.Image)
-		result := analysis.RunLive(ecosystem, name, version, sb, manager.CommandFmt(name, version))
+		result := analysis.RunLive(ecosystem, name, version, sb, manager.Command("all", name, version, ""))
 
 		if resultsBucket != "" {
 			err = analysis.UploadResults(ctx, resultsBucket, ecosystem+"/"+name, result)

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -51,9 +51,9 @@ const (
 	maxIndexEntries = 10000
 )
 
-func RunLocal(ecosystem, pkgPath, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
+func RunLocal(ecosystem, pkgPath, localPkg, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
 	return run(ecosystem, pkgPath, version, sb, command, []string{
-		"-v", fmt.Sprintf("%s:%s", pkgPath, pkgPath),
+		"-v", fmt.Sprintf("%s:%s", localPkg, localPkg),
 	})
 }
 

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -3,7 +3,6 @@ package analysis
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 
 	"github.com/ossf/package-analysis/internal/dnsanalyzer"
@@ -51,19 +50,8 @@ const (
 	maxIndexEntries = 10000
 )
 
-func RunLocal(ecosystem, pkgPath, localPkg, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
-	return run(ecosystem, pkgPath, version, sb, command, []string{
-		"-v", fmt.Sprintf("%s:%s", localPkg, localPkg),
-	})
-}
-
-func RunLive(ecosystem, pkgName, version string, sb sandbox.Sandbox, command string) *AnalysisResult {
-	return run(ecosystem, pkgName, version, sb, command, nil)
-}
-
-func run(ecosystem, pkgName, version string, sb sandbox.Sandbox, command string, args []string) *AnalysisResult {
+func Run(ecosystem, pkgName, version string, sb sandbox.Sandbox, args []string) *AnalysisResult {
 	log.Info("Running analysis",
-		"command", command,
 		"args", args)
 
 	// Init the sandbox
@@ -91,9 +79,8 @@ func run(ecosystem, pkgName, version string, sb sandbox.Sandbox, command string,
 
 	// Run the command
 	log.Debug("Running the command",
-		"command", command,
 		"args", args)
-	r, err := sb.Run(command, args...)
+	r, err := sb.Run(args...)
 	if err != nil {
 		log.Panic("Command exited unsucessfully",
 			"error", err)

--- a/internal/pkgecosystem/ecosystem.go
+++ b/internal/pkgecosystem/ecosystem.go
@@ -1,10 +1,12 @@
 package pkgecosystem
 
+import "strings"
+
 type PkgManager struct {
-	Name       string
-	CommandFmt func(string, string) string
-	GetLatest  func(string) string
-	Image      string
+	Name        string
+	CommandPath string
+	GetLatest   func(string) string
+	Image       string
 }
 
 var (
@@ -18,4 +20,35 @@ var (
 // String implements the Stringer interface to support pretty printing.
 func (p PkgManager) String() string {
 	return p.Name
+}
+
+// escape ensures that args being used are safely escaped for usage.
+func escape(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// Command returns the analysis command for the given package.
+func (p PkgManager) Command(phase, pkg, ver, local string) string {
+	args := make([]string, 0)
+	args = append(args, p.CommandPath)
+
+	if local != "" {
+		args = append(args, "--local", escape(local))
+	} else if ver != "" {
+		args = append(args, "--version", escape(ver))
+	}
+
+	if phase == "" {
+		args = append(args, "all")
+	} else {
+		args = append(args, phase)
+	}
+
+	args = append(args, escape(pkg))
+
+	return strings.Join(args, " ")
 }

--- a/internal/pkgecosystem/ecosystem.go
+++ b/internal/pkgecosystem/ecosystem.go
@@ -1,12 +1,9 @@
 package pkgecosystem
 
-import "strings"
-
 type PkgManager struct {
-	Name        string
-	CommandPath string
-	GetLatest   func(string) string
-	Image       string
+	Name      string
+	GetLatest func(string) string
+	Image     string
 }
 
 var (
@@ -22,24 +19,14 @@ func (p PkgManager) String() string {
 	return p.Name
 }
 
-// escape ensures that args being used are safely escaped for usage.
-func escape(s string) string {
-	if len(s) == 0 {
-		return "''"
-	}
-
-	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
-}
-
-// Command returns the analysis command for the given package.
-func (p PkgManager) Command(phase, pkg, ver, local string) string {
+// Args returns the analysis arguments for the given package.
+func (p PkgManager) Args(phase, pkg, ver, local string) []string {
 	args := make([]string, 0)
-	args = append(args, p.CommandPath)
 
 	if local != "" {
-		args = append(args, "--local", escape(local))
+		args = append(args, "--local", local)
 	} else if ver != "" {
-		args = append(args, "--version", escape(ver))
+		args = append(args, "--version", ver)
 	}
 
 	if phase == "" {
@@ -48,7 +35,7 @@ func (p PkgManager) Command(phase, pkg, ver, local string) string {
 		args = append(args, phase)
 	}
 
-	args = append(args, escape(pkg))
+	args = append(args, pkg)
 
-	return strings.Join(args, " ")
+	return args
 }

--- a/internal/pkgecosystem/npm.go
+++ b/internal/pkgecosystem/npm.go
@@ -31,8 +31,7 @@ func getNPMLatest(pkg string) string {
 }
 
 var NPMPackageManager = PkgManager{
-	Name:        "npm",
-	Image:       "gcr.io/ossf-malware-analysis/node",
-	CommandPath: "analyze.js",
-	GetLatest:   getNPMLatest,
+	Name:      "npm",
+	Image:     "gcr.io/ossf-malware-analysis/node",
+	GetLatest: getNPMLatest,
 }

--- a/internal/pkgecosystem/npm.go
+++ b/internal/pkgecosystem/npm.go
@@ -31,14 +31,8 @@ func getNPMLatest(pkg string) string {
 }
 
 var NPMPackageManager = PkgManager{
-	Name:  "npm",
-	Image: "gcr.io/ossf-malware-analysis/node",
-	CommandFmt: func(pkg, ver string) string {
-		if ver != "" {
-			return fmt.Sprintf("analyze.js %s@%s", pkg, ver)
-		}
-
-		return fmt.Sprintf("analyze.js %s", pkg)
-	},
-	GetLatest: getNPMLatest,
+	Name:        "npm",
+	Image:       "gcr.io/ossf-malware-analysis/node",
+	CommandPath: "analyze.js",
+	GetLatest:   getNPMLatest,
 }

--- a/internal/pkgecosystem/pypi.go
+++ b/internal/pkgecosystem/pypi.go
@@ -31,14 +31,8 @@ func getPyPILatest(pkg string) string {
 }
 
 var PyPIPackageManager = PkgManager{
-	Name:  "pypi",
-	Image: "gcr.io/ossf-malware-analysis/python",
-	CommandFmt: func(pkg, ver string) string {
-		if ver != "" {
-			return fmt.Sprintf("analyze.py %s==%s", pkg, ver)
-		}
-
-		return fmt.Sprintf("analyze.py %s", pkg)
-	},
-	GetLatest: getPyPILatest,
+	Name:        "pypi",
+	Image:       "gcr.io/ossf-malware-analysis/python",
+	CommandPath: "analyze.py",
+	GetLatest:   getPyPILatest,
 }

--- a/internal/pkgecosystem/pypi.go
+++ b/internal/pkgecosystem/pypi.go
@@ -31,8 +31,7 @@ func getPyPILatest(pkg string) string {
 }
 
 var PyPIPackageManager = PkgManager{
-	Name:        "pypi",
-	Image:       "gcr.io/ossf-malware-analysis/python",
-	CommandPath: "analyze.py",
-	GetLatest:   getPyPILatest,
+	Name:      "pypi",
+	Image:     "gcr.io/ossf-malware-analysis/python",
+	GetLatest: getPyPILatest,
 }

--- a/internal/pkgecosystem/rubygems.go
+++ b/internal/pkgecosystem/rubygems.go
@@ -29,8 +29,7 @@ func getRubyGemsLatest(pkg string) string {
 }
 
 var RubyGemsPackageManager = PkgManager{
-	Name:        "rubygems",
-	Image:       "gcr.io/ossf-malware-analysis/ruby",
-	CommandPath: "analyze.rb",
-	GetLatest:   getRubyGemsLatest,
+	Name:      "rubygems",
+	Image:     "gcr.io/ossf-malware-analysis/ruby",
+	GetLatest: getRubyGemsLatest,
 }

--- a/internal/pkgecosystem/rubygems.go
+++ b/internal/pkgecosystem/rubygems.go
@@ -29,13 +29,8 @@ func getRubyGemsLatest(pkg string) string {
 }
 
 var RubyGemsPackageManager = PkgManager{
-	Name:  "rubygems",
-	Image: "gcr.io/ossf-malware-analysis/ruby",
-	CommandFmt: func(pkg, ver string) string {
-		if ver != "" {
-			return fmt.Sprintf("analyze.rb %s %s", pkg, ver)
-		}
-		return fmt.Sprintf("analyze.rb %s", pkg)
-	},
-	GetLatest: getRubyGemsLatest,
+	Name:        "rubygems",
+	Image:       "gcr.io/ossf-malware-analysis/ruby",
+	CommandPath: "analyze.rb",
+	GetLatest:   getRubyGemsLatest,
 }

--- a/sandboxes/README.md
+++ b/sandboxes/README.md
@@ -157,6 +157,8 @@ The container must include:
 - the package manager used by the analysis command
 - system libraries used by the majority of packages
 
+The `Dockerfile` must also set the analysis command as the `ENTRYPOINT`.
+
 ### Wiring It Up
 
 1. Update [build_docker.sh](../build/build_docker.sh) to reference the image.

--- a/sandboxes/npm/Dockerfile
+++ b/sandboxes/npm/Dockerfile
@@ -8,3 +8,5 @@ FROM scratch
 COPY --from=image / /
 ENV NODE_PATH /app/node_modules
 WORKDIR /app
+
+ENTRYPOINT [ "/usr/local/bin/analyze.js" ]

--- a/sandboxes/npm/analyze.js
+++ b/sandboxes/npm/analyze.js
@@ -13,6 +13,8 @@ if (argv.length < 2 || argv > 4) {
   process.exit(1);
 }
 
+// Parse the arguments manually to avoid introducing unnecessary dependencies
+// and side effects that add noise to the strace output.
 var localFile = null;
 var ver = null;
 switch (argv[0]) {

--- a/sandboxes/pypi/Dockerfile
+++ b/sandboxes/pypi/Dockerfile
@@ -7,3 +7,5 @@ RUN mkdir -p /app
 FROM scratch
 COPY --from=image / /
 WORKDIR /app
+
+ENTRYPOINT [ "/usr/local/bin/analyze.py" ]

--- a/sandboxes/pypi/analyze.py
+++ b/sandboxes/pypi/analyze.py
@@ -59,6 +59,8 @@ def main():
     if len(args) < 2 or len(args) > 4:
         raise ValueError(f'Usage: {script} [--local file | --version version] phase package_name')
 
+    # Parse the arguments manually to avoid introducing unnecessary dependencies
+    # and side effects that add noise to the strace output.
     local_package = None
     version = None
     if args[0] == '--local':

--- a/sandboxes/pypi/analyze.py
+++ b/sandboxes/pypi/analyze.py
@@ -53,13 +53,36 @@ def analyze(package):
 
 
 def main():
-    if len(sys.argv) != 2:
-        raise ValueError(f'Usage: {sys.argv[0]} package_name[==version]')
+    args = list(sys.argv)
+    script = args.pop(0)
 
-    package_with_version = sys.argv[1]
-    pip_install(package_with_version)
+    if len(args) < 2 or len(args) > 4:
+        raise ValueError(f'Usage: {script} [--local file | --version version] phase package_name')
 
-    package = package_with_version.split('==')[0]
+    local_package = None
+    version = None
+    if args[0] == '--local':
+        args.pop(0)
+        local_package = args.pop(0)
+    elif args[0] == '--version':
+        args.pop(0)
+        version = args.pop(0)
+
+    phase = args.pop(0)
+    package = args.pop(0)
+
+    if phase != 'all':
+        print('Only "all" phase is supported at the moment')
+        exit(1)
+
+    if local_package:
+        install_package = local_package
+    elif version:
+        install_package = f'{package}=={version}'
+    else:
+        install_package = package
+
+    pip_install(install_package)
     analyze(package)
 
 

--- a/sandboxes/rubygems/Dockerfile
+++ b/sandboxes/rubygems/Dockerfile
@@ -7,3 +7,5 @@ RUN mkdir -p /app
 FROM scratch
 COPY --from=image / /
 WORKDIR /app
+
+ENTRYPOINT [ "/usr/local/bin/analyze.rb" ]

--- a/sandboxes/rubygems/analyze.rb
+++ b/sandboxes/rubygems/analyze.rb
@@ -40,6 +40,8 @@ end
 local_file = nil
 version = nil
 
+# Parse the arguments manually to avoid introducing unnecessary dependencies
+# and side effects that add noise to the strace output.
 case ARGV[0]
 when "--local"
   ARGV.shift


### PR DESCRIPTION
**Note**: This is a breaking change:
 - new sandbox images won't work with old versions of the analyze and worker commands
 - old sandbox images won't work with the updated analyze and worker commands.

Changes:
- update the spec slightly surrounding the usage of `--local FILE` and `--version VERSION`.
- support the `all` phase in dynamic analysis sandboxes.
- escapes package name, package filename and version when passing it through to the podman command to prevent shell command injection.
- requires `-package` to always be specified so that files being installed can be imported correctly.