### PR TITLE
Fix broken npm analyze.js command

### DIFF
--- a/sandboxes/npm/analyze.js
+++ b/sandboxes/npm/analyze.js
@@ -75,10 +75,10 @@ const package = {
   localFile: localFile,
 };
 
-if (!phases.keys().includes(phase)) {
+if (!Array.from(phases.keys()).includes(phase)) {
   console.log(`Unknown phase ${phase} specified.`);
   process.exit(1);
 }
 
 // Execute the phase
-phases[phase].forEach((f) => f(package));
+phases.get(phase).forEach((f) => f(package));


### PR DESCRIPTION
Turns out `Map.keys()`:
- returns an interator, not an `Array`
- requires `get(key)` to return the value for a given key.