### PR TITLE
Support tagged releases for images

### DIFF
--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -2,6 +2,11 @@
 
 nopush=${NOPUSH:-"false"}
 
+tag=""
+if [ "$RELEASE_TAG" != "" ]; then
+  tag=":$RELEASE_TAG"
+fi
+
 BASE_PATH="$(dirname $(dirname $(realpath $0)))"
 REGISTRY=gcr.io/ossf-malware-analysis
 
@@ -10,7 +15,7 @@ declare -A ANALYSIS_IMAGES=( [node]=npm [python]=pypi [ruby]=rubygems )
 
 pushd "$BASE_PATH/sandboxes"
 for image in "${!ANALYSIS_IMAGES[@]}"; do
-  docker build -t $REGISTRY/$image ${ANALYSIS_IMAGES[$image]}
+  docker build -t $REGISTRY/$image$tag ${ANALYSIS_IMAGES[$image]}
   [[ "$nopush" == "false" ]]  && docker push $REGISTRY/$image
 done
 popd
@@ -20,7 +25,7 @@ declare -A CMD_IMAGES=( [analysis]=analyze [scheduler]=scheduler )
 
 pushd "$BASE_PATH"
 for image in "${!CMD_IMAGES[@]}"; do
-  docker build -t $REGISTRY/$image -f cmd/${CMD_IMAGES[$image]}/Dockerfile .
+  docker build -t $REGISTRY/$image$tag -f cmd/${CMD_IMAGES[$image]}/Dockerfile .
   [[ "$nopush" == "false" ]] && docker push $REGISTRY/$image
 done
 popd

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -1,5 +1,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  env:
+  - 'RELEASE_TAG=$TAG_NAME'
   entrypoint: bash
   dir: build
   args: ['-ex', 'build_docker.sh']

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -26,3 +26,6 @@ RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
 
 COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
+
+ARG SANDBOX_IMAGE_TAG
+ENV OSSF_SANDBOX_IMAGE_TAG=${SANDBOX_IMAGE_TAG}

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -19,6 +19,7 @@ var (
 	version   = flag.String("version", "", "version")
 	upload    = flag.String("upload", "", "bucket path for uploading results")
 	noPull    = flag.Bool("nopull", false, "disables pulling down sandbox images")
+	imageTag  = flag.String("image-tag", "", "set a image tag")
 )
 
 func parseBucketPath(path string) (string, string) {
@@ -70,9 +71,13 @@ func main() {
 
 	args := manager.Args("all", *pkg, *version, *localPkg)
 
-	// Prepare the sandbox to use ensuring we respect the -"nopull" option and
-	// any local package is mapped through.
-	sbOpts := make([]sandbox.Option, 0)
+	// Prepare the sandbox:
+	// - Always pass through the tag. An empty tag is the same as "latest".
+	// - Respect the "-nopull" option.
+	// - Ensure any local package is mapped through.
+	sbOpts := []sandbox.Option{
+		sandbox.Tag(*imageTag),
+	}
 	if *noPull {
 		sbOpts = append(sbOpts, sandbox.NoPull())
 	}

--- a/infra/terraform/analysis.tf
+++ b/infra/terraform/analysis.tf
@@ -13,5 +13,13 @@ terraform {
 module "docker_registry" {
   source = "./docker_registry"
 
-  project               = var.project
+  project = var.project
+}
+
+module "build" {
+  source = "./build"
+
+  project = var.project
+  github_owner = var.github_owner
+  github_repo = var.github_repo
 }

--- a/infra/terraform/build/main.tf
+++ b/infra/terraform/build/main.tf
@@ -1,0 +1,16 @@
+# Google Cloud Build Triggers
+
+resource "google_cloudbuild_trigger" "image-build-trigger" {
+  name = "image-build-trigger"
+  project = var.project
+
+  github {
+    owner = var.github_owner
+    name = var.github_repo
+    push {
+        tag = "^rel-[0-9]+$"
+    }
+  }
+
+  filename = "build/cloudbuild.yaml"
+}

--- a/infra/terraform/build/variables.tf
+++ b/infra/terraform/build/variables.tf
@@ -1,4 +1,3 @@
 variable "project" {}
-variable "region" {}
 variable "github_owner" {}
 variable "github_repo" {}

--- a/infra/terraform/terraform.tfvars
+++ b/infra/terraform/terraform.tfvars
@@ -1,2 +1,4 @@
-project = "ossf-malware-analysis"
-region  = "us-central1"
+project      = "ossf-malware-analysis"
+region       = "us-central1"
+github_owner = "ossf"
+github_repo  = "package-analysis"


### PR DESCRIPTION
When this repo is tagged with a tag that matches the pattern `rel-[0-9]+` a cloud build trigger is fired that starts building docker images.

- The trigger is configured using terraform (currently deployed)
- The tag is used as a tag for docker container images
- The tag is used in the worker/analysis image to ensure the corresponding sandbox images are used - this is to ensure that the behavior between the two remains consistent.

Once a release has been tagged and the images built a `kubectl rollout restart statefulset/workers-set` should start the workers using the latest release version. 