### PR TITLE
Support multiple phases of dynamic analysis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,4 @@ infra
 examples
 function
 sandboxes
-tools
 web

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -21,11 +21,13 @@ RUN apt-get update && apt-get upgrade -y && \
 
 # Install gVisor.
 RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
-    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases 20210601 main" && \
+    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases 20211129 main" && \
     apt-get update && apt-get install -y runsc
 
 COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
+COPY --from=build /src/tools/gvisor/runsc_compat.sh /usr/local/bin/runsc_compat.sh
+RUN chmod 755 /usr/local/bin/runsc_compat.sh
 
 ARG SANDBOX_IMAGE_TAG
 ENV OSSF_SANDBOX_IMAGE_TAG=${SANDBOX_IMAGE_TAG}

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	sb := sandbox.New(manager.Image(), sbOpts...)
 	if err := sb.Start(); err != nil {
-		log.Panic("start failed", "error", err)
+		log.Panic("Failed to start sandbox", "error", err)
 	}
 	defer sb.Stop()
 	results := make(map[string]*analysis.Result)

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -9,11 +9,12 @@ import (
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
+	"github.com/ossf/package-analysis/internal/resultstore"
 	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
 var (
-	pkg       = flag.String("package", "", "package name")
+	pkgName   = flag.String("package", "", "package name")
 	localPkg  = flag.String("local", "", "local package path")
 	ecosystem = flag.String("ecosystem", "", "ecosystem (npm, pypi, or rubygems)")
 	version   = flag.String("version", "", "version")
@@ -40,36 +41,45 @@ func main() {
 		return
 	}
 
-	manager, ok := pkgecosystem.SupportedPkgManagers[*ecosystem]
-	if !ok {
+	manager := pkgecosystem.Manager(*ecosystem)
+	if manager == nil {
 		log.Panic("Unsupported pkg manager",
 			log.Label("ecosystem", *ecosystem))
 	}
 
-	if *pkg == "" {
+	if *pkgName == "" {
 		flag.Usage()
 		return
 	}
 
-	live := true
-	if *localPkg == "" {
-		if *version == "" {
-			*version = manager.GetLatest(*pkg)
-		}
-	} else {
-		live = false
+	log.Info("Got request",
+		log.Label("ecosystem", *ecosystem),
+		log.Label("name", *pkgName),
+		log.Label("localPath", *localPkg),
+		log.Label("version", *version))
+
+	var pkg *pkgecosystem.Pkg
+	var err error
+	if *localPkg != "" {
 		if *version != "" {
 			log.Panic("Unable to specify version for local packages")
+		}
+		pkg = manager.Local(*pkgName, *version, *localPkg)
+	} else if *version != "" {
+		pkg = manager.Package(*pkgName, *version)
+	} else {
+		pkg, err = manager.Latest(*pkgName)
+		if err != nil {
+			log.Panic("Failed to get latest version",
+				log.Label("ecosystem", *ecosystem),
+				log.Label("name", *pkgName))
 		}
 	}
 
 	log.Info("Got request",
 		log.Label("ecosystem", *ecosystem),
-		log.Label("name", *pkg),
-		log.Label("version", *version),
-		"live", live)
-
-	args := manager.Args("all", *pkg, *version, *localPkg)
+		log.Label("name", *pkgName),
+		log.Label("version", *version))
 
 	// Prepare the sandbox:
 	// - Always pass through the tag. An empty tag is the same as "latest".
@@ -81,17 +91,25 @@ func main() {
 	if *noPull {
 		sbOpts = append(sbOpts, sandbox.NoPull())
 	}
-	if !live {
+	if *localPkg != "" {
 		sbOpts = append(sbOpts, sandbox.Volume(*localPkg, *localPkg))
 	}
 
-	sb := sandbox.New(manager.Image, sbOpts...)
-	result := analysis.Run(*ecosystem, *pkg, *version, sb, args)
+	sb := sandbox.New(manager.Image(), sbOpts...)
+	if err := sb.Start(); err != nil {
+		log.Panic("start failed", "error", err)
+	}
+	defer sb.Stop()
+	results := make(map[string]*analysis.Result)
+	for _, phase := range manager.DynamicPhases() {
+		result := analysis.Run(sb, pkg.Command(phase))
+		results[phase] = result
+	}
 
 	ctx := context.Background()
 	if *upload != "" {
 		bucket, path := parseBucketPath(*upload)
-		err := analysis.UploadResults(ctx, bucket, path, result)
+		err := resultstore.New(bucket, resultstore.BasePath(path)).Save(ctx, pkg, results)
 		if err != nil {
 			log.Fatal("Failed to upload results to blobstore",
 				"error", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
+	"github.com/ossf/package-analysis/internal/resultstore"
 	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
@@ -48,8 +49,8 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		return nil
 	}
 
-	manager, ok := pkgecosystem.SupportedPkgManagers[ecosystem]
-	if !ok {
+	manager := pkgecosystem.Manager(ecosystem)
+	if manager == nil {
 		log.Warn("Unsupported pkg manager",
 			log.Label("ecosystem", ecosystem),
 			log.Label("name", name))
@@ -58,10 +59,6 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 	}
 
 	version := msg.Metadata["version"]
-	if version == "" {
-		version = manager.GetLatest(name)
-	}
-
 	pkgPath := msg.Metadata["package_path"]
 
 	resultsBucketOverride := msg.Metadata["results_bucket_override"]
@@ -108,11 +105,34 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		sbOpts = append(sbOpts, sandbox.Volume(f.Name(), localPkgPath))
 	}
 
-	sb := sandbox.New(manager.Image, sbOpts...)
-	result := analysis.Run(ecosystem, name, version, sb, manager.Args("all", name, version, localPkgPath))
+	var pkg *pkgecosystem.Pkg
+	var err error
+	if localPkgPath != "" {
+		pkg = manager.Local(name, version, localPkgPath)
+	} else if version != "" {
+		pkg = manager.Package(name, version)
+	} else {
+		pkg, err = manager.Latest(name)
+		if err != nil {
+			log.Panic("Failed to get latest version",
+				log.Label("ecosystem", ecosystem),
+				log.Label("name", name))
+		}
+	}
+
+	sb := sandbox.New(manager.Image(), sbOpts...)
+	if err := sb.Start(); err != nil {
+		log.Panic("Failed to start sandbox", "error", err)
+	}
+	defer sb.Stop()
+	results := make(map[string]*analysis.Result)
+	for _, phase := range manager.DynamicPhases() {
+		result := analysis.Run(sb, pkg.Command(phase))
+		results[phase] = result
+	}
 
 	if resultsBucket != "" {
-		err := analysis.UploadResults(ctx, resultsBucket, ecosystem+"/"+name, result)
+		err := resultstore.New(resultsBucket, resultstore.ConstructPath()).Save(ctx, pkg, results)
 		if err != nil {
 			return fmt.Errorf("failed to upload to blobstore = %w", err)
 		}

--- a/internal/pkgecosystem/ecosystem.go
+++ b/internal/pkgecosystem/ecosystem.go
@@ -1,41 +1,72 @@
 package pkgecosystem
 
+import (
+	"strings"
+)
+
 type PkgManager struct {
-	Name      string
-	GetLatest func(string) string
-	Image     string
+	name          string
+	image         string
+	command       string
+	latest        func(string) (string, error)
+	dynamicPhases []string
 }
 
 var (
-	SupportedPkgManagers = map[string]PkgManager{
-		NPMPackageManager.Name:      NPMPackageManager,
-		PyPIPackageManager.Name:     PyPIPackageManager,
-		RubyGemsPackageManager.Name: RubyGemsPackageManager,
+	supportedPkgManagers = map[string]*PkgManager{
+		npmPkgManager.name:      &npmPkgManager,
+		pypiPkgManager.name:     &pypiPkgManager,
+		rubygemsPkgManager.name: &rubygemsPkgManager,
 	}
 )
 
-// String implements the Stringer interface to support pretty printing.
-func (p PkgManager) String() string {
-	return p.Name
+func Manager(ecosystem string) *PkgManager {
+	return supportedPkgManagers[ecosystem]
 }
 
-// Args returns the analysis arguments for the given package.
-func (p PkgManager) Args(phase, pkg, ver, local string) []string {
-	args := make([]string, 0)
+// String implements the Stringer interface to support pretty printing.
+func (p *PkgManager) String() string {
+	return p.name
+}
 
-	if local != "" {
-		args = append(args, "--local", local)
-	} else if ver != "" {
-		args = append(args, "--version", ver)
+func (p *PkgManager) Image() string {
+	return p.image
+}
+
+func (p *PkgManager) DynamicPhases() []string {
+	return p.dynamicPhases
+}
+
+func (p *PkgManager) Latest(name string) (*Pkg, error) {
+	name = normalizePkgName(name)
+	version, err := p.latest(name)
+	if err != nil {
+		return nil, err
 	}
+	return &Pkg{
+		name:    name,
+		version: version,
+		manager: p,
+	}, nil
+}
 
-	if phase == "" {
-		args = append(args, "all")
-	} else {
-		args = append(args, phase)
+func (p *PkgManager) Local(name, version, localPath string) *Pkg {
+	return &Pkg{
+		name:    normalizePkgName(name),
+		version: version,
+		local:   localPath,
+		manager: p,
 	}
+}
 
-	args = append(args, pkg)
+func (p *PkgManager) Package(name, version string) *Pkg {
+	return &Pkg{
+		name:    normalizePkgName(name),
+		version: version,
+		manager: p,
+	}
+}
 
-	return args
+func normalizePkgName(pkg string) string {
+	return strings.ToLower(pkg)
 }

--- a/internal/pkgecosystem/npm.go
+++ b/internal/pkgecosystem/npm.go
@@ -3,7 +3,6 @@ package pkgecosystem
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -13,10 +12,10 @@ type npmJSON struct {
 	} `json:"dist-tags"`
 }
 
-func getNPMLatest(pkg string) string {
+func getNPMLatest(pkg string) (string, error) {
 	resp, err := http.Get(fmt.Sprintf("https://registry.npmjs.org/%s", pkg))
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
@@ -24,14 +23,19 @@ func getNPMLatest(pkg string) string {
 	var details npmJSON
 	err = decoder.Decode(&details)
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 
-	return details.DistTags.Latest
+	return details.DistTags.Latest, nil
 }
 
-var NPMPackageManager = PkgManager{
-	Name:      "npm",
-	Image:     "gcr.io/ossf-malware-analysis/node",
-	GetLatest: getNPMLatest,
+var npmPkgManager = PkgManager{
+	name:    "npm",
+	image:   "gcr.io/ossf-malware-analysis/node",
+	command: "/usr/local/bin/analyze.js",
+	latest:  getNPMLatest,
+	dynamicPhases: []string{
+		"install",
+		"import",
+	},
 }

--- a/internal/pkgecosystem/package.go
+++ b/internal/pkgecosystem/package.go
@@ -1,0 +1,51 @@
+package pkgecosystem
+
+type Pkg struct {
+	name    string
+	version string
+	manager *PkgManager
+	local   string
+	command string
+}
+
+func (p *Pkg) Name() string {
+	return p.name
+}
+
+func (p *Pkg) Version() string {
+	return p.version
+}
+
+func (p *Pkg) Ecosystem() string {
+	return p.manager.name
+}
+
+func (p *Pkg) IsLocal() bool {
+	return p.local != ""
+}
+
+func (p *Pkg) Manager() *PkgManager {
+	return p.manager
+}
+
+// Command returns the analysis command for the package.
+func (p *Pkg) Command(phase string) []string {
+	args := make([]string, 0)
+	args = append(args, p.manager.command)
+
+	if p.local != "" {
+		args = append(args, "--local", p.local)
+	} else if p.version != "" {
+		args = append(args, "--version", p.version)
+	}
+
+	if phase == "" {
+		args = append(args, "all")
+	} else {
+		args = append(args, phase)
+	}
+
+	args = append(args, p.name)
+
+	return args
+}

--- a/internal/pkgecosystem/pypi.go
+++ b/internal/pkgecosystem/pypi.go
@@ -3,7 +3,6 @@ package pkgecosystem
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -13,10 +12,10 @@ type pypiJSON struct {
 	} `json:"info"`
 }
 
-func getPyPILatest(pkg string) string {
+func getPyPILatest(pkg string) (string, error) {
 	resp, err := http.Get(fmt.Sprintf("https://pypi.org/pypi/%s/json", pkg))
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
@@ -24,14 +23,19 @@ func getPyPILatest(pkg string) string {
 	var details pypiJSON
 	err = decoder.Decode(&details)
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 
-	return details.Info.Version
+	return details.Info.Version, nil
 }
 
-var PyPIPackageManager = PkgManager{
-	Name:      "pypi",
-	Image:     "gcr.io/ossf-malware-analysis/python",
-	GetLatest: getPyPILatest,
+var pypiPkgManager = PkgManager{
+	name:    "pypi",
+	image:   "gcr.io/ossf-malware-analysis/python",
+	command: "/usr/local/bin/analyze.py",
+	latest:  getPyPILatest,
+	dynamicPhases: []string{
+		"install",
+		"import",
+	},
 }

--- a/internal/pkgecosystem/rubygems.go
+++ b/internal/pkgecosystem/rubygems.go
@@ -3,7 +3,6 @@ package pkgecosystem
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -11,10 +10,10 @@ type rubygemsJSON struct {
 	Version string `json:"version"`
 }
 
-func getRubyGemsLatest(pkg string) string {
+func getRubyGemsLatest(pkg string) (string, error) {
 	resp, err := http.Get(fmt.Sprintf("https://rubygems.org/api/v1/gems/%s.json", pkg))
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
@@ -22,14 +21,19 @@ func getRubyGemsLatest(pkg string) string {
 	var details rubygemsJSON
 	err = decoder.Decode(&details)
 	if err != nil {
-		log.Panic(err)
+		return "", err
 	}
 
-	return details.Version
+	return details.Version, nil
 }
 
-var RubyGemsPackageManager = PkgManager{
-	Name:      "rubygems",
-	Image:     "gcr.io/ossf-malware-analysis/ruby",
-	GetLatest: getRubyGemsLatest,
+var rubygemsPkgManager = PkgManager{
+	name:    "rubygems",
+	image:   "gcr.io/ossf-malware-analysis/ruby",
+	command: "/usr/local/bin/analyze.rb",
+	latest:  getRubyGemsLatest,
+	dynamicPhases: []string{
+		"install",
+		"import",
+	},
 }

--- a/internal/resultstore/result.go
+++ b/internal/resultstore/result.go
@@ -1,0 +1,21 @@
+package resultstore
+
+// Pkg describes the various package details used to populate the package part
+// of the analysis results.
+type Pkg interface {
+	Name() string
+	Version() string
+	Ecosystem() string
+}
+
+type pkg struct {
+	Name      string
+	Version   string
+	Ecosystem string
+}
+
+type result struct {
+	Package          pkg
+	CreatedTimestamp int64
+	Analysis         interface{}
+}

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -1,0 +1,101 @@
+package resultstore
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"time"
+
+	"github.com/ossf/package-analysis/internal/log"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/fileblob"
+	_ "gocloud.dev/blob/gcsblob"
+	_ "gocloud.dev/blob/s3blob"
+)
+
+type ResultStore struct {
+	bucket        string
+	basePath      string
+	constructPath bool
+}
+
+type Option interface{ set(*ResultStore) }
+type option func(*ResultStore)       // option implements Option.
+func (o option) set(sb *ResultStore) { o(sb) }
+
+// ConstructPath will cause Save() to generate the path based on Pkg.Ecosystem()
+// and Pkg.Name().
+func ConstructPath() Option {
+	return option(func(rs *ResultStore) { rs.constructPath = true })
+}
+
+// BasePath sets the base path used while saving files to storage.
+func BasePath(base string) Option {
+	return option(func(rs *ResultStore) { rs.basePath = base })
+}
+
+func New(bucket string, options ...Option) *ResultStore {
+	rs := &ResultStore{
+		bucket: bucket,
+	}
+	for _, o := range options {
+		o.set(rs)
+	}
+	return rs
+}
+
+func (rs *ResultStore) generatePath(p Pkg) string {
+	path := rs.basePath
+	if rs.constructPath {
+		path = filepath.Join(path, p.Ecosystem(), p.Name())
+	}
+	return path
+}
+
+func (rs *ResultStore) Save(ctx context.Context, p Pkg, analysis interface{}) error {
+	version := p.Version()
+	result := &result{
+		Package: pkg{
+			Name:      p.Name(),
+			Ecosystem: p.Ecosystem(),
+			Version:   version,
+		},
+		CreatedTimestamp: time.Now().UTC().Unix(),
+		Analysis:         analysis,
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	bkt, err := blob.OpenBucket(ctx, rs.bucket)
+	if err != nil {
+		return err
+	}
+	defer bkt.Close()
+
+	filename := "results.json"
+	if version != "" {
+		filename = version + ".json"
+	}
+
+	path := rs.generatePath(p)
+	uploadPath := filepath.Join(path, filename)
+	log.Info("Uploading results",
+		"bucket", rs.bucket,
+		"path", uploadPath)
+
+	w, err := bkt.NewWriter(ctx, uploadPath, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sandboxes/npm/Dockerfile
+++ b/sandboxes/npm/Dockerfile
@@ -9,4 +9,6 @@ COPY --from=image / /
 ENV NODE_PATH /app/node_modules
 WORKDIR /app
 
-ENTRYPOINT [ "/usr/local/bin/analyze.js" ]
+ENTRYPOINT [ "sleep" ]
+
+CMD [ "30m" ]

--- a/sandboxes/pypi/Dockerfile
+++ b/sandboxes/pypi/Dockerfile
@@ -8,4 +8,6 @@ FROM scratch
 COPY --from=image / /
 WORKDIR /app
 
-ENTRYPOINT [ "/usr/local/bin/analyze.py" ]
+ENTRYPOINT [ "sleep" ]
+
+CMD [ "30m" ]

--- a/sandboxes/pypi/analyze.py
+++ b/sandboxes/pypi/analyze.py
@@ -70,7 +70,7 @@ def importPkg(package):
 PHASES = {
     "all": [install, importPkg],
     "install": [install],
-    "importPkg": [importPkg]
+    "import": [importPkg]
 }
 
 def main():
@@ -95,7 +95,7 @@ def main():
     package_name = args.pop(0)
 
     if not phase in PHASES:
-        print(f'Unknown phase ${phase} specified.')
+        print(f'Unknown phase {phase} specified.')
         exit(1)
 
     package = Package(name=package_name, version=version, local_path=local_path)

--- a/sandboxes/rubygems/Dockerfile
+++ b/sandboxes/rubygems/Dockerfile
@@ -8,4 +8,6 @@ FROM scratch
 COPY --from=image / /
 WORKDIR /app
 
-ENTRYPOINT [ "/usr/local/bin/analyze.rb" ]
+ENTRYPOINT [ "sleep" ]
+
+CMD [ "30m" ]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,3 @@
 # Package Analysis Tools
 
-This directory contains scripts and tools useful during development and testing.
+This directory contains scripts and tools.

--- a/tools/gvisor/README.md
+++ b/tools/gvisor/README.md
@@ -1,0 +1,20 @@
+# GVisor Scripts
+
+## `runsc_compat.sh`
+
+This script improves the compatibility of `runsc` when it is used by
+[Podman](https://podman.io).
+
+This project uses [GVisor](https://github.com/google/gvisor)'s OCI runtime
+`runsc` to provide a sandbox for analyzing packages. The `runsc` sandbox is used
+by setting it as the runtime for Podman running inside a Docker container.
+
+Unfortunately there are slight differences in the flags passed from Podman
+(specifically `conmon`) to the `runsc`.
+
+In particular, when `podman exec` is called on a running container, the `-d`
+(detach) flag is passed by `conmon` to the OCI runtime. However this flag is not
+supported by `runsc`. Instead `runsc` supports `-detach`.
+
+So, to ensure `runsc` works correctly with Podman this script will turn `-d`
+into `-detach` when `exec` is called.

--- a/tools/gvisor/runsc_compat.sh
+++ b/tools/gvisor/runsc_compat.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+BIN="/usr/bin/runsc"
+
+IS_EXEC=0
+for arg; do
+    if [ "$arg" == "exec" ]; then
+        IS_EXEC=1
+    fi
+done
+
+
+# GVisor's runsc does not support "-d" which is passed to it from conmon.
+# runc supports "-d" for running detached so translate the "-d" argument to
+# the "-detach" flavor supported by runsc.
+if [ $IS_EXEC -eq 1 ]; then
+    declare -a NEWARGS
+    for arg; do
+        if [ "$arg" == "-d" ]; then
+            NEWARGS+=("-detach")
+        else
+            NEWARGS+=("$arg")
+        fi
+    done
+    set -- "${NEWARGS[@]}"
+fi
+
+exec "$BIN" "$@"


### PR DESCRIPTION
Initial support of multiple phases of dynamic analysis.

This adds support for an "install" and "import" phase for each ecosystem.

Some changes:

- the podman container is started with a "sleep" and each phase is "exec"d in the same container.
  - pcaps supported this nicely, but straces are for all phases are logged to one file. To handle this, the size of the log file is recorded before + after each phase so we can read the straces that apply only to the phase we are interested in.
- a `runsc_compat.sh` script was introduced to help `runsc` work with `podman`/`conmon` correctly for `exec`.
- the `pkgecosystem` logic was slightly refactored
- result storage now lives in `resultstore`