### PR TITLE
Improve the multi-phase sandbox behavior

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -96,10 +96,7 @@ func main() {
 	}
 
 	sb := sandbox.New(manager.Image(), sbOpts...)
-	if err := sb.Start(); err != nil {
-		log.Panic("Failed to start sandbox", "error", err)
-	}
-	defer sb.Stop()
+	defer sb.Clean()
 	results := make(map[string]*analysis.Result)
 	for _, phase := range manager.DynamicPhases() {
 		result := analysis.Run(sb, pkg.Command(phase))

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -126,10 +126,7 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 	}
 
 	sb := sandbox.New(manager.Image(), sbOpts...)
-	if err := sb.Start(); err != nil {
-		log.Panic("Failed to start sandbox", "error", err)
-	}
-	defer sb.Stop()
+	defer sb.Clean()
 	results := make(map[string]*analysis.Result)
 	for _, phase := range manager.DynamicPhases() {
 		result := analysis.Run(sb, pkg.Command(phase))


### PR DESCRIPTION
- Execute each phase in a start + exec + stop sequence to simplify log processing. Be aware this also means the "sleep" command now appears in the list of commands.
- Use a temp dir for logging for each phase so they aren't destroyed between each run
- Read the container ID from create rather than hardcoding a box id -> avoids issues if a container fails to be stopped/destroyed