### PR TITLE
Apply read-all permissions to all the workflows.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,6 +2,8 @@ name: "Build docker"
 
 on: [pull_request, push]
 
+permissions: read-all
+
 jobs:
   build_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: "Build"
 on:
   pull_request:
 
+permissions: read-all
+
 jobs:
   Build:
     name:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '22 19 * * 0'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: "Test"
 on:
   pull_request:
 
+permissions: read-all
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remediate some of the scorecard results by adding `permissions:read-all` to all the workflows.