### PR TITLE
Add a status, stdout and stderr to the results returned for each command

### DIFF
--- a/internal/analysis/output.go
+++ b/internal/analysis/output.go
@@ -1,0 +1,36 @@
+package analysis
+
+// lastLines returns a byte array containing only the last maxLines of lines
+// in b.
+//
+// A line is defined the by the occurance of a '\n' in the output.
+//
+// If there are fewer than maxLines then the entire intput byte array will be
+// returned.
+//
+// No more than maxBytes will be in the returned byte array.
+func lastLines(b []byte, maxLines, maxBytes int) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	// only consider the last maxBytes of b, or all of b if maxBytes is bigger
+	// than the size of b.
+	startOff := len(b) - maxBytes
+	if startOff < 0 {
+		startOff = 0
+	}
+	b = b[startOff:]
+	// count each newline from the end of the bufffer
+	lines := 0
+	lineOff := len(b) - 1
+	for off := len(b) - 1; off > 0; off-- {
+		if b[off] == '\n' {
+			lines++
+			lineOff = off
+		}
+		if lines > maxLines {
+			return b[lineOff+1:]
+		}
+	}
+	return b
+}

--- a/internal/analysis/output_test.go
+++ b/internal/analysis/output_test.go
@@ -1,0 +1,46 @@
+package analysis
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEmptyBuffer(t *testing.T) {
+	b := []byte{}
+	if test := lastLines(b, 10, 100); len(test) > 0 {
+		t.Fatalf("lastLines() = %v; want empty byte array", test)
+	}
+}
+
+func TestSmallBuffer(t *testing.T) {
+	b := []byte("hello world")
+	if test := lastLines(b, 10, 100); !bytes.Equal(test, b) {
+		t.Fatalf("lastLines() = %v, want %v", test, b)
+	}
+}
+
+func TestSmallBufferWithFewLines(t *testing.T) {
+	b := []byte("hello\nworld\n")
+	if test := lastLines(b, 10, 100); !bytes.Equal(test, b) {
+		t.Fatalf("lastLines() = %v, want %v", test, b)
+	}
+}
+
+func TestSmallBufferWithManyLines(t *testing.T) {
+	b := []byte("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n")
+	exp := []byte("six\nseven\neight\nnine\nten\n")
+	if test := lastLines(b, 5, 100); !bytes.Equal(test, exp) {
+		t.Fatalf("lastLines() = %v, want %v", test, exp)
+	}
+}
+
+func TestBigBufferWithNoLines(t *testing.T) {
+	b := make([]byte, 1000, 1000)
+	for i := range b {
+		b[i] = 'a' + byte(i%26)
+	}
+	exp := []byte("qrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl")
+	if test := lastLines(b, 10, 100); !bytes.Equal(test, exp) {
+		t.Fatalf("lastLines() = %v (%d), want %v (%d)", test, len(test), exp, len(exp))
+	}
+}


### PR DESCRIPTION
The stdout and stderr is limited to the last 20 lines (max 4k bytes) from each.

This makes it easier to debug and measure the pipeline's quality.