### PR TITLE
Set schema during BQ load.

### DIFF
--- a/function/loader/README.md
+++ b/function/loader/README.md
@@ -5,3 +5,17 @@ BigQuery.
 
 We use this instead of the BigQuery Data Transfer service as it does not support
 load jobs with WRITE_TRUNCATE.
+
+To deploy this:
+
+```bash
+gcloud functions deploy load-data \
+    --region=us-central1 \
+    --project=ossf-malware-analysis \
+    --entry-point=Load \
+    --memory=512MB \
+    --runtime=go116 \
+    --timeout=120s \
+    --trigger-topic=load-data \
+    --set-env-vars=OSSF_MALWARE_ANALYSIS_RESULTS=ossf-malware-analysis-results,GCP_PROJECT=ossf-malware-analysis
+```

--- a/function/loader/schema.json
+++ b/function/loader/schema.json
@@ -1,0 +1,202 @@
+[
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "fields": [
+              {
+                "mode": "REPEATED",
+                "name": "Environment",
+                "type": "STRING"
+              },
+              {
+                "mode": "REPEATED",
+                "name": "Command",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Commands",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
+                "mode": "REPEATED",
+                "name": "Hostnames",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Port",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Address",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Sockets",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Stderr",
+            "type": "STRING"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "Write",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Read",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Path",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Files",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Stdout",
+            "type": "BYTES"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Status",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "install",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "fields": [
+              {
+                "mode": "REPEATED",
+                "name": "Environment",
+                "type": "STRING"
+              },
+              {
+                "mode": "REPEATED",
+                "name": "Command",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Commands",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
+                "mode": "REPEATED",
+                "name": "Hostnames",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Port",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Address",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Sockets",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Stderr",
+            "type": "STRING"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "Write",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Read",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Path",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "Files",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Stdout",
+            "type": "BYTES"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Status",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "import",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "Analysis",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "CreatedTimestamp",
+    "type": "INTEGER"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "Ecosystem",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "Version",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "Name",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "Package",
+    "type": "RECORD"
+  }
+]


### PR DESCRIPTION
Autodetect fails to detect the new format, as many entries do not have
a "import" section.