### PR TITLE
Fix volume arguments passed to sandbox.

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -197,9 +197,9 @@ func (s *podmanSandbox) createContainer() (string, error) {
 		"--runtime=" + runtimeBin,
 		"--init",
 		"--hostname=" + hostname,
-		s.imageWithTag(),
 	}
 	args = append(args, s.extraArgs()...)
+	args = append(args, s.imageWithTag())
 	cmd := podman(args...)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf


### PR DESCRIPTION
Previously they were being passed after the image name, resulting in
them being passed as arguments to the container entrypoint ("sleep").