### PR TITLE
Limit any race conditions that might arise during packet capture.

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -91,10 +91,7 @@ func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 		"args", args)
 
 	log.Debug("Preparing packet capture")
-	pcap, err := packetcapture.New()
-	if err != nil {
-		return resultError, fmt.Errorf("failed to init packet capture (%w)", err)
-	}
+	pcap := packetcapture.New()
 
 	dns := dnsanalyzer.New()
 	pcap.RegisterReceiver(dns)


### PR DESCRIPTION
- Use immediate mode to avoid any buffering, so our code gets the packets as soon as possible.
- Add a "done" signal to the goroutine, so all outstanding packets are processed after closing the pcap's handle.

It is possible that immediate mode may cause extra resource churn, but, according to the docs, it is possible for packets to remain undelivered if timeouts are used.

This attempts to fix #228