### PR TITLE
Improve the functionality of the sandbox images so more packages run successfully and failures are more obvious

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -102,10 +102,19 @@ func main() {
 		result, err := analysis.Run(sb, pkg.Command(phase))
 		if err != nil {
 			log.Fatal("Analysis phase failed",
-				"phase", phase,
+				log.Label("phase", phase),
 				"error", err)
 		}
 		results[phase] = result
+		// Abort if install failed. No need to continue.
+		if result.Status != analysis.StatusCompleted {
+			log.Error("Analysis phase failed. Cannot continue.",
+				log.Label("phase", phase),
+				log.Label("ecosystem", *ecosystem),
+				log.Label("name", *pkgName),
+				log.Label("version", *version))
+			break
+		}
 	}
 
 	ctx := context.Background()

--- a/sandboxes/npm/Dockerfile
+++ b/sandboxes/npm/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod 755 /usr/local/bin/analyze.js
 RUN mkdir -p /app
 
 # If an npm package tries to use bower, make sure bower can run under root.
-RUN echo "{ \"allow-root\": true }" > /app/.bowerrc
+COPY bowerrc /app/.bowerrc
 
 FROM scratch
 COPY --from=image / /

--- a/sandboxes/npm/Dockerfile
+++ b/sandboxes/npm/Dockerfile
@@ -1,8 +1,16 @@
 FROM node:16.1.0-slim@sha256:972548af5d81a09288fe9bb1b7291ff0c4e4e41e4b2e5f5ca80a80fc363e62f3 as image
 
+RUN apt-get update && \
+    apt-get install -y \
+        wget \
+        git
+
 COPY analyze.js /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.js
 RUN mkdir -p /app
+
+# If an npm package tries to use bower, make sure bower can run under root.
+RUN echo "{ \"allow-root\": true }" > /app/.bowerrc
 
 FROM scratch
 COPY --from=image / /

--- a/sandboxes/npm/analyze.js
+++ b/sandboxes/npm/analyze.js
@@ -16,15 +16,13 @@ function install(package) {
     throw 'Failed to init npm';
   }
 
-  result = spawnSync('npm', ['install', installPkg], { stdio: 'pipe', encoding: 'utf8' });
-  console.log(result.stdout + result.stderr);
-
+  result = spawnSync('npm', ['install', installPkg], { stdio: 'inherit' });
   if (result.status == 0) {
     console.log('Install succeeded.');
   } else {
-    if (result.stderr.includes('is not in the npm registry.')) {
-      process.exit(0);
-    }
+    // Always exit on failure.
+    // Install failing is either an interesting issue, or an opportunity to
+    // improve the analysis.
     console.log('Install failed.');
     process.exit(1);
   }

--- a/sandboxes/npm/bowerrc
+++ b/sandboxes/npm/bowerrc
@@ -1,0 +1,1 @@
+{ "allow-root": true }

--- a/sandboxes/pypi/Dockerfile
+++ b/sandboxes/pypi/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.9.5-slim@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049facd2703e57892447 as image
 
+RUN apt-get update && \
+    apt-get install -y \
+        wget \
+        git
+
+# Some Python packages expect certain dependencies to already be installed.
+RUN pip install requests urllib3
+
 COPY analyze.py /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.py
 RUN mkdir -p /app

--- a/sandboxes/pypi/analyze.py
+++ b/sandboxes/pypi/analyze.py
@@ -29,17 +29,16 @@ def install(package):
     arg = package.install_arg()
     try:
       output = subprocess.check_output(
-          (sys.executable, '-m', 'pip', 'install', arg),
+          (sys.executable, '-m', 'pip', 'install', '--pre', arg),
           stderr=subprocess.STDOUT)
       print('Install succeeded:')
       print(output.decode())
     except subprocess.CalledProcessError as e:
       print('Failed to install:')
       print(e.output.decode())
-      if b'No matching distribution' in e.output:
-          sys.exit(0)
-
-      # Some other unknown error.
+      # Always raise.
+      # Install failing is either an interesting issue, or an opportunity to
+      # improve the analysis.
       raise
 
 def path_to_import(path):

--- a/sandboxes/rubygems/Dockerfile
+++ b/sandboxes/rubygems/Dockerfile
@@ -1,5 +1,10 @@
 FROM ruby:3.0.1-slim@sha256:3c0f26c0071ccdd6b5ab0c3ed615cd1f0cfd30b0039d1d5d7c2e70c66441e09a as image
 
+RUN apt-get update && \
+    apt-get install -y \
+        wget \
+        git
+
 COPY analyze.rb /usr/local/bin/
 RUN chmod 755 /usr/local/bin/analyze.rb
 RUN mkdir -p /app

--- a/sandboxes/rubygems/analyze.rb
+++ b/sandboxes/rubygems/analyze.rb
@@ -32,11 +32,10 @@ def install(package)
     return
   end
 
+  # Always exit on failure.
+  # Install failing is either an interesting issue, or an opportunity to
+  # improve the analysis.
   puts "Install failed."
-  if output.include? "Could not find a valid gem"
-    exit 0
-  end
-
   exit 1
 end
 


### PR DESCRIPTION
1. An install failure always causes the analysis to abort with an error - so it is easier to see when installs are failing. This may also be a signal for the quality of the library.
2. Add "wget" and "git" to the images to make sure packages that try to use them succeed.
3. Add "requests" and "urllib3" to the Python base image so that packages that _assume_ they're present succeed to run. setup.py hacks may also assume they exist.
4. Add a ".bowerrc" file to allow NPM packages using bower to install as root.
5. Pass "--pre" to pip to allow dev packages to be installed