### PR TITLE
Add curl to the sandboxes to make them more representative.

### DIFF
--- a/sandboxes/npm/Dockerfile
+++ b/sandboxes/npm/Dockerfile
@@ -2,6 +2,7 @@ FROM node:16.1.0-slim@sha256:972548af5d81a09288fe9bb1b7291ff0c4e4e41e4b2e5f5ca80
 
 RUN apt-get update && \
     apt-get install -y \
+        curl \
         wget \
         git
 

--- a/sandboxes/pypi/Dockerfile
+++ b/sandboxes/pypi/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9.5-slim@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049fac
 
 RUN apt-get update && \
     apt-get install -y \
+        curl \
         wget \
         git
 

--- a/sandboxes/rubygems/Dockerfile
+++ b/sandboxes/rubygems/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:3.0.1-slim@sha256:3c0f26c0071ccdd6b5ab0c3ed615cd1f0cfd30b0039d1d5d7c2e
 
 RUN apt-get update && \
     apt-get install -y \
+        curl \
         wget \
         git
 


### PR DESCRIPTION
`curl` is frequently used to exfiltrate data or pull down payloads so lets add it to sandboxes.

Helps improve #146 