### PR TITLE
Collect and add DNS queries to the analysis results.

### DIFF
--- a/function/loader/schema.json
+++ b/function/loader/schema.json
@@ -6,6 +6,35 @@
           {
             "fields": [
               {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "Hostname",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "REPEATED",
+                    "name": "Types",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "Queries",
+                "type": "RECORD"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Class",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "DNS",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
                 "mode": "REPEATED",
                 "name": "Environment",
                 "type": "STRING"

--- a/function/loader/schema.json
+++ b/function/loader/schema.json
@@ -118,6 +118,35 @@
           {
             "fields": [
               {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "Hostname",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "REPEATED",
+                    "name": "Types",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "Queries",
+                "type": "RECORD"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "Class",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "DNS",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
                 "mode": "REPEATED",
                 "name": "Environment",
                 "type": "STRING"

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -73,6 +73,10 @@ type commandResult struct {
 	Environment []string
 }
 
+type dnsResult struct {
+	Queries map[string]map[string][]string
+}
+
 type Result struct {
 	Status   status
 	Stdout   []byte
@@ -80,6 +84,7 @@ type Result struct {
 	Files    []fileResult
 	Sockets  []socketResult
 	Commands []commandResult
+	DNS      dnsResult
 }
 
 var (
@@ -156,4 +161,7 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 		})
 	}
 
+	d.DNS = dnsResult{
+		Queries: dns.Questions(),
+	}
 }

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -73,8 +73,14 @@ type commandResult struct {
 	Environment []string
 }
 
+type dnsQueries struct {
+	Hostname string
+	Types    []string
+}
+
 type dnsResult struct {
-	Queries map[string]map[string][]string
+	Class   string
+	Queries []dnsQueries
 }
 
 type Result struct {
@@ -84,7 +90,7 @@ type Result struct {
 	Files    []fileResult
 	Sockets  []socketResult
 	Commands []commandResult
-	DNS      dnsResult
+	DNS      []dnsResult
 }
 
 var (
@@ -161,7 +167,14 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 		})
 	}
 
-	d.DNS = dnsResult{
-		Queries: dns.Questions(),
+	for dnsClass, queries := range dns.Questions() {
+		c := dnsResult{Class: dnsClass}
+		for host, types := range queries {
+			c.Queries = append(c.Queries, dnsQueries{
+				Hostname: host,
+				Types:    types,
+			})
+		}
+		d.DNS = append(d.DNS, c)
 	}
 }


### PR DESCRIPTION
DNS requests made during the analysis phase are stored and added to the analysis result.

Currently this only captures DNS over TCP or UDP. Any DNS queries over HTTPS or TLS are not captured.