### PR TITLE
Bump GVisor version. It now supports cgroups v2.

### DIFF
--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get upgrade -y && \
 
 # Install gVisor.
 RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
-    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases 20211129 main" && \
+    add-apt-repository "deb https://storage.googleapis.com/gvisor/releases 20220425 main" && \
     apt-get update && apt-get install -y runsc
 
 COPY --from=build /src/analyze /usr/local/bin/analyze


### PR DESCRIPTION
GVisor added support for cgroups v2 in late 2022. This change updates GVisor to a version that includes these changes.

This will avoid the need to switch to cgroups v1 support and make it easier for people to use the project.

This should resolve #271.