### PR TITLE
Separate sandbox traffic to avoid capturing host packets during analysis.

### DIFF
--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get upgrade -y && \
         ca-certificates \
         curl \
         iptables \
-        libpcap0.8 \
+        iproute2 \
         podman \
         software-properties-common && \
     update-alternatives --set iptables /usr/sbin/iptables-legacy && \
@@ -27,8 +27,10 @@ RUN curl -fsSL https://gvisor.dev/archive.key | apt-key add - && \
 COPY --from=build /src/analyze /usr/local/bin/analyze
 COPY --from=build /src/worker /usr/local/bin/worker
 COPY --from=build /src/tools/gvisor/runsc_compat.sh /usr/local/bin/runsc_compat.sh
-COPY --from=build /src/tools/firewall/iptables.rules /usr/local/etc/iptables.rules
-RUN chmod 755 /usr/local/bin/runsc_compat.sh
+COPY --from=build /src/tools/network/iptables.rules /usr/local/etc/iptables.rules
+COPY --from=build /src/tools/network/podman-analysis.conflist /etc/cni/net.d/podman-analysis.conflist
+RUN chmod 755 /usr/local/bin/runsc_compat.sh && \
+    chmod 644 /usr/local/etc/iptables.rules /etc/cni/net.d/podman-analysis.conflist
 
 ARG SANDBOX_IMAGE_TAG
 ENV OSSF_SANDBOX_IMAGE_TAG=${SANDBOX_IMAGE_TAG}

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -35,6 +35,8 @@ func parseBucketPath(path string) (string, string) {
 
 func main() {
 	log.Initalize(os.Getenv("LOGGER_ENV"))
+	sandbox.InitEnv()
+
 	flag.Parse()
 	if *ecosystem == "" {
 		flag.Usage()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -229,6 +229,7 @@ func main() {
 	resultsBucket := os.Getenv("OSSF_MALWARE_ANALYSIS_RESULTS")
 	imageTag := os.Getenv("OSSF_SANDBOX_IMAGE_TAG")
 	log.Initalize(os.Getenv("LOGGER_ENV"))
+	sandbox.InitEnv()
 
 	// Log the configuration of the worker at startup so we can observe it.
 	log.Info("Starting worker",

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -102,7 +102,7 @@ func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 		"args", args)
 
 	log.Debug("Preparing packet capture")
-	pcap := packetcapture.New()
+	pcap := packetcapture.New(sandbox.NetworkInterface)
 
 	dns := dnsanalyzer.New()
 	pcap.RegisterReceiver(dns)
@@ -119,6 +119,7 @@ func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 		return resultError, fmt.Errorf("sandbox failed (%w)", err)
 	}
 
+	log.Debug("Stop the packet capture")
 	pcap.Close()
 
 	// Grab the log file

--- a/internal/packetcapture/packetcapture.go
+++ b/internal/packetcapture/packetcapture.go
@@ -17,8 +17,7 @@ type PacketReceiver interface {
 type Handler func(gopacket.Layer, gopacket.Packet)
 
 type PacketCapture struct {
-	netInterface string
-	//handle          *afpacket.TPacket
+	netInterface    string
 	handle          *pcapgo.EthernetHandle
 	done            chan bool
 	stop            chan bool
@@ -55,7 +54,9 @@ func (pc *PacketCapture) RegisterReceiver(receiver PacketReceiver) {
 }
 
 func (pc *PacketCapture) Start() error {
-	//handle, err := afpacket.NewTPacket(afpacket.OptInterface(pc.netInterface))
+	// Use the pcapgo library for capturing traffic as it is the most reliable.
+	// afpacket is the fastest but segfaults: https://github.com/google/gopacket/issues/717
+	// pcap will block during Cancel(): https://github.com/google/gopacket/issues/890
 	handle, err := pcapgo.NewEthernetHandle(pc.netInterface)
 	if err != nil {
 		return err

--- a/internal/sandbox/init.go
+++ b/internal/sandbox/init.go
@@ -1,0 +1,130 @@
+package sandbox
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/ossf/package-analysis/internal/log"
+)
+
+const (
+	ipBin           = "/usr/sbin/ip"
+	iptablesLoadBin = "/usr/sbin/iptables-restore"
+	iptablesRules   = "/usr/local/etc/iptables.rules"
+	dummyInterface  = "cnidummy0"
+
+	// bridgeInterface is the name of the podman bridge defined in
+	// tools/network/podman-analysis.conflist. This bridge is used by the
+	// sandbox during analysis to separate the sandbox traffic from the host.
+	bridgeInterface = "cni-analysis"
+)
+
+const (
+	// NetworkInterface is the name of a network interface that has access to
+	// the sandbox network traffic.
+	NetworkInterface = bridgeInterface
+)
+
+func loadIptablesRules() error {
+	log.Debug("Loading iptable rules")
+
+	// Open the iptables-restore configuration
+	f, err := os.Open(iptablesRules)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	logOut := log.Writer(log.InfoLevel)
+	defer logOut.Close()
+	logErr := log.Writer(log.WarnLevel)
+	defer logErr.Close()
+
+	cmd := exec.Command(iptablesLoadBin)
+	cmd.Stdout = logOut
+	cmd.Stderr = logErr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	defer stdin.Close()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Send the iptables rules to the command via stdin
+	if _, err := io.Copy(stdin, f); err != nil {
+		return err
+	}
+	stdin.Close()
+	return cmd.Wait()
+}
+
+// createBridgeNetwork ensures that NetworkInterface and the bridge network
+// exists prior to the sandbox.
+//
+// podman would create this bridge interface anyway, but doing it early allows
+// a packet capture to be started on the interface prior to the sandbox
+// starting.
+func createBridgeNetwork() error {
+	log.Debug("Creating bridge network")
+
+	// Create the bridge
+	cmd := exec.Command(ipBin, "link", "add", "name", bridgeInterface, "type", "bridge")
+	if err := cmd.Run(); err != nil {
+		// If the error is not an ExitError, or the Exit Code is not 2, then abort.
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 2 {
+			return fmt.Errorf("failed to add bridge interface: %w", err)
+		}
+	}
+
+	// Bring the bridge up.
+	cmd = exec.Command(ipBin, "link", "set", bridgeInterface, "up")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to bring up bridge interface: %w", err)
+	}
+
+	// Add a dummy device so the bridge stays up
+	cmd = exec.Command(ipBin, "link", "add", "dev", dummyInterface, "type", "dummy")
+	if err := cmd.Run(); err != nil {
+		// If the error is not an ExitError, or the Exit Code is not 2, then abort.
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 2 {
+			return fmt.Errorf("failed to create dummy inteface: %w", err)
+		}
+	}
+
+	// Add the dummy device to the bridge network
+	cmd = exec.Command(ipBin, "link", "set", "dev", dummyInterface, "master", bridgeInterface)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to add dummy interface to bridge: %w", err)
+	}
+
+	// Bring the dummy device up.
+	cmd = exec.Command(ipBin, "link", "set", dummyInterface, "up")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to bring up dummy interface: %w", err)
+	}
+
+	return nil
+}
+
+// InitEnv initializes the host for running sandboxes.
+//
+// It will ensure that the network interface exists, and any firewall
+// rules are configured.
+//
+// This function is idempotent and is safe to be called more than once.
+//
+// This function must be called after logging is complete, and may exit if
+// any of the commands fail.
+func InitEnv() {
+	// Create the bridge network
+	if err := createBridgeNetwork(); err != nil {
+		log.Fatal("Failed to create bridge network", "error", err)
+	}
+	// Load iptables rules to further isolate the sandbox
+	if err := loadIptablesRules(); err != nil {
+		log.Fatal("Failed restoring iptables rules", "error", err)
+	}
+}

--- a/tools/network/iptables.rules
+++ b/tools/network/iptables.rules
@@ -1,13 +1,16 @@
 # Create the chain used by podman networking for user-defined rules
+#
+# Note: the subnet "172.16.16.0/24" used here must match the subnet
+# used in podman-analysis.conflist.
 *filter
 :INPUT ACCEPT [0:0]
 :CNI-ADMIN - [0:0]
 # Block access to this host from the container network.
--A INPUT -s {{ .Subnet }} -j DROP
+-A INPUT -s 172.16.16.0/24 -j DROP
 # Block access to metadata.google.internal/AWS metadata.
 -A CNI-ADMIN -d 169.254.169.254/32 -j DROP
 # Block access to Private address spaces.
--A CNI-ADMIN -s {{ .Subnet }} -d 10.0.0.0/8 -j DROP
--A CNI-ADMIN -s {{ .Subnet }} -d 172.16.0.0/12 -j DROP
--A CNI-ADMIN -s {{ .Subnet }} -d 192.168.0.0/16 -j DROP
+-A CNI-ADMIN -s 172.16.16.0/24 -d 10.0.0.0/8 -j DROP
+-A CNI-ADMIN -s 172.16.16.0/24 -d 172.16.0.0/12 -j DROP
+-A CNI-ADMIN -s 172.16.16.0/24 -d 192.168.0.0/16 -j DROP
 COMMIT

--- a/tools/network/podman-analysis.conflist
+++ b/tools/network/podman-analysis.conflist
@@ -1,0 +1,28 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "analysis-net",
+  "plugins": [
+    {
+        "type": "bridge",
+        "bridge": "cni-analysis",
+        "isGateway": true,
+        "ipMasq": true,
+        "hairpinMode": true,
+        "ipam": {
+            "type": "host-local",
+            "subnet": "172.16.16.0/24",
+            "routes": [
+                { "dst": "0.0.0.0/0" }
+            ]
+        }
+    },
+    {
+        "type": "portmap",
+        "capabilities": { "portMappings": true }
+    },
+    {
+        "type": "firewall",
+        "backend": "iptables"
+    }
+  ]
+}


### PR DESCRIPTION
`podman pull` can occur on the host after pcap is started, polluting the results with network noise.

This change puts the sandbox traffic onto a bridge network that can be captured separately to the host, removing any host traffic from the captured network traffic.