### PR TITLE
Don't push built images by default and bump Ubuntu to 22.04 for analysis image

### DIFF
--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-nopush=${NOPUSH:-"true"}
+push=${PUSH:-"false"}
 tag=${RELEASE_TAG}
 
 BASE_PATH="$(dirname $(dirname $(realpath $0)))"
@@ -16,7 +16,7 @@ for image in "${!ANALYSIS_IMAGES[@]}"; do
     extra_args="-t $REGISTRY/$image:$tag"
   fi
   docker build $extra_args -t $REGISTRY/$image ${ANALYSIS_IMAGES[$image]}
-  [[ "$nopush" == "false" ]]  && docker push $REGISTRY/$image
+  [[ "$push" == "true" ]] && docker push $REGISTRY/$image
 done
 popd
 
@@ -30,6 +30,6 @@ for image in "${!CMD_IMAGES[@]}"; do
     extra_args="-t $REGISTRY/$image:$tag --build-arg=SANDBOX_IMAGE_TAG=$tag"
   fi
   docker build $extra_args -t $REGISTRY/$image -f cmd/${CMD_IMAGES[$image]}/Dockerfile .
-  [[ "$nopush" == "false" ]] && docker push $REGISTRY/$image
+  [[ "$push" == "true" ]] && docker push $REGISTRY/$image
 done
 popd

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-nopush=${NOPUSH:-"false"}
+nopush=${NOPUSH:-"true"}
 tag=${RELEASE_TAG}
 
 BASE_PATH="$(dirname $(dirname $(realpath $0)))"

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   env:
   - 'RELEASE_TAG=$TAG_NAME'
+  - 'NOPUSH=false'
   entrypoint: bash
   dir: build
   args: ['-ex', 'build_docker.sh']

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   env:
   - 'RELEASE_TAG=$TAG_NAME'
-  - 'NOPUSH=false'
+  - 'PUSH=true'
   entrypoint: bash
   dir: build
   args: ['-ex', 'build_docker.sh']

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /src
 COPY . ./
 RUN go build -o analyze cmd/analyze/main.go && go build -o worker cmd/worker/main.go
 
-FROM ubuntu:21.04@sha256:be154cc2b1211a9f98f4d708f4266650c9129784d0485d4507d9b0fa05d928b6
+# FROM ubuntu:21.04@sha256:be154cc2b1211a9f98f4d708f4266650c9129784d0485d4507d9b0fa05d928b6
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && \

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -4,8 +4,7 @@ WORKDIR /src
 COPY . ./
 RUN go build -o analyze cmd/analyze/main.go && go build -o worker cmd/worker/main.go
 
-# FROM ubuntu:21.04@sha256:be154cc2b1211a9f98f4d708f4266650c9129784d0485d4507d9b0fa05d928b6
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:42ba2dfce475de1113d55602d40af18415897167d47c2045ec7b6d9746ff148f
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && \

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -10,7 +10,7 @@ To build the necessary images yourself for the docker-compose, you can do the fo
 ```
 # In package-analysis
 cd build
-NOPUSH=true ./build_docker.sh
+./build_docker.sh
 
 # In package-feeds
 docker build . -t docker.pkg.github.com/ossf/package-feeds/packagefeeds:latest

--- a/infra/README.md
+++ b/infra/README.md
@@ -19,5 +19,5 @@ To update container images, run:
 
 ```shell
 $ cd build
-$ ./build_docker.sh
+$ PUSH=true ./build_docker.sh
 ```


### PR DESCRIPTION
Fixes #333 and #334 