### PR TITLE
Chmod the sandbox logDir so that it can be read by non-root users.

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -301,6 +301,10 @@ func (s *podmanSandbox) Run(args ...string) (*RunResult, error) {
 	if err != nil {
 		return &RunResult{}, fmt.Errorf("failed to create log directory: %w", err)
 	}
+	// Chmod the log dir so it can be read by non-root users.
+	if err := os.Chmod(logDir, 0o775); err != nil {
+		return &RunResult{}, fmt.Errorf("failed to chmod log directory: %w", err)
+	}
 
 	// Prepare the run result.
 	var stdout bytes.Buffer

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/ossf/package-analysis/internal/log"
 )
@@ -301,8 +303,12 @@ func (s *podmanSandbox) Run(args ...string) (*RunResult, error) {
 	if err != nil {
 		return &RunResult{}, fmt.Errorf("failed to create log directory: %w", err)
 	}
-	// Chmod the log dir so it can be read by non-root users.
-	if err := os.Chmod(logDir, 0o775); err != nil {
+	// Chmod the log dir so it can be read by non-root users. Make the behaviour
+	// mimic Mkdir called with 0o777 before umask is applied by applying the
+	// umask manually to the permissions.
+	umask := syscall.Umask(0)
+	syscall.Umask(umask)
+	if err := os.Chmod(logDir, fs.FileMode(0o777 & ^umask)); err != nil {
 		return &RunResult{}, fmt.Errorf("failed to chmod log directory: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #360.

Example:

```shell
$ ls -l /tmp/docker/
total 8
drwxrwxr-x 2 root root 4096 Sep 14 15:15 sandbox_logs_1902203493/
drwxrwxr-x 2 root root 4096 Sep 14 15:16 sandbox_logs_3929266306/
$ ls -l /tmp/docker/sandbox_logs_1902203493/
total 56884
-rw-r--r-- 1 root root 58227740 Sep 14 15:16 runsc.log.boot
-rw-r--r-- 1 root root     2770 Sep 14 15:15 runsc.log.create
-rw-r--r-- 1 root root     6304 Sep 14 15:16 runsc.log.gofer
-rw-r--r-- 1 root root     1749 Sep 14 15:15 runsc.log.start
```

Signed-off-by: Caleb Brown <calebbrown@google.com>