### PR TITLE
Bump the replicas + requested resources to improve scalability.

### DIFF
--- a/infra/worker/scaler.yaml
+++ b/infra/worker/scaler.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pubsub
 spec:
   minReplicas: 1
-  maxReplicas: 200
+  maxReplicas: 750
   metrics:
   - external:
       metric:

--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -36,8 +36,8 @@ spec:
             name: image-storage
         resources:
           requests:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 750m
+            memory: 768Mi
           limits:
             cpu: 1
             memory: 2Gi


### PR DESCRIPTION
750 replicas was enough to process tens of thousands of requests per day.

The additional requested resources help avoid issues with the available CPU/memory when scheduling work.

Signed-off-by: Caleb Brown <calebbrown@google.com>