### PR TITLE
Upgrade to Go 1.19.1

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,7 +19,7 @@ jobs:
     - name: setup-go
       uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2.1.5
       with:
-        go-version: '1.17.1'
+        go-version: '1.19.1'
 
     - name: Enable docker experimental
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v2.4.0
     - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2.1.5
       with:
-        go-version: '1.17.1'
+        go-version: '1.19.1'
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - run: go build -o scheduler cmd/scheduler/main.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v2.4.0
     - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2.1.5
       with:
-        go-version: 1.17.1
+        go-version: 1.19.1
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ developement.
 
 ### Required Dependencies
 
-- Go v1.17
+- Go v1.19
 - Docker
 - libpcap-dev
 

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang@sha256:3c4de86eec9cbc619cdd72424abd88326ffcf5d813a8338a7743c55e5898734f as build
+FROM golang@sha256:122f3484f844467ebe0674cf57272e61981770eb0bc7d316d1f0be281a88229f as build
 RUN apt-get update && apt-get install -y libpcap-dev
 WORKDIR /src
 

--- a/cmd/scheduler/Dockerfile
+++ b/cmd/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang@sha256:3c4de86eec9cbc619cdd72424abd88326ffcf5d813a8338a7743c55e5898734f as build
+FROM golang@sha256:122f3484f844467ebe0674cf57272e61981770eb0bc7d316d1f0be281a88229f as build
 WORKDIR /src
 
 # First cache the dependencies to avoid downloading again on code change

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/package-analysis
 
-go 1.17
+go 1.19
 
 require (
 	github.com/blendle/zapdriver v1.3.1


### PR DESCRIPTION
Upgrade to use Go 1.19.1

Some dependencies no longer support Go 1.17, so it's time to update.