### PR TITLE
Update the e2e docs and switch the scheduled-feeds image.

### DIFF
--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -10,7 +10,7 @@ $ docker-compose up -d
 $ curl localhost:8080
 ```
 
-Requesting `localhost:8080` will trigger package-feeds to poll it's feeds and send the packages downstream to package-analysis.
+Requesting `localhost:8080` will trigger package-feeds to poll its feeds and send the packages downstream to package-analysis.
 
 You may need to run `curl` again if package-feeds is not yet running.
 
@@ -49,7 +49,7 @@ $ chmod ugo+r ./config/feeds.yml
 
 ### Sandbox container is not starting (cgroups v2)
 
-If the `analysis` logs show failures when trying to start the sandbox container, your machine may be configured to us cgroups v2.
+If the `analysis` logs show failures when trying to start the sandbox container, your machine may need to be configured to use cgroups v2.
 
 To work with cgroups v2 you will need to:
 
@@ -61,7 +61,11 @@ To work with cgroups v2 you will need to:
 }
 ```
 
-2. restart dockerd (if it is running)
+2. restart dockerd (if it is running). e.g.:
+
+```shell
+$ systemctl restart docker.service
+```
 
 ### Obtaining the necessary images (Optional)
 

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -2,9 +2,71 @@
 
 This example provides a simple way to spin up an end to end deployment of package-feeds and the package-analysis sub projects, allowing for easy demonstration of behaviour of the system as a whole.
 
-## Obtaining the necessary images
+## Running
 
-Images can be pulled from the relevant repositories however some require credentials (github for package-feeds).
+```shell
+$ cd examples/e2e # must be run from the e2e folder
+$ docker-compose up -d
+$ curl localhost:8080
+```
+
+Requesting `localhost:8080` will trigger package-feeds to poll it's feeds and send the packages downstream to package-analysis.
+
+You may need to run `curl` again if package-feeds is not yet running.
+
+## Analysis Output
+
+Output can be found at http://localhost:9000/minio/package-analysis,
+using the following credentials for authentication:
+
+- username: `minio`
+- password: `minio123`
+
+## Logs Access
+
+`docker-compose logs -f feeds` will provide information on the packages which have been send downstream.
+
+`docker-compose logs -f scheduler` will provide information on the packages which have been received and proxied onto the analysis workers.
+
+`docker-compose logs -f analysis` provides too much stdout to be useful, outputs are sent to minio as mentioned above.
+
+## Additional Notes
+
+### Limitations
+
+- Locally built sandbox images are currently ignored.
+
+### Feeds does not start (missing config)
+
+This can happen if `./config` is not world-readable. You will see the error message `open /config/feeds.yml: permission denied` in the feeds logs.
+
+To fix simply run:
+
+```shell
+$ chmod ugo+rx ./config
+$ chmod ugo+r ./config/feeds.yml
+```
+
+### Sandbox container is not starting (cgroups v2)
+
+If the `analysis` logs show failures when trying to start the sandbox container, your machine may be configured to us cgroups v2.
+
+To work with cgroups v2 you will need to:
+
+1. add/edit `/etc/docker/daemon.json` and the following:
+
+```json
+{
+    "default-cgroupns-mode": "host"
+}
+```
+
+2. restart dockerd (if it is running)
+
+### Obtaining the necessary images (Optional)
+
+Images are pulled automatically from the relevant repositories.
+
 To build the necessary images yourself for the docker-compose, you can do the following:
 
 ```
@@ -13,21 +75,5 @@ cd build
 ./build_docker.sh
 
 # In package-feeds
-docker build . -t docker.pkg.github.com/ossf/package-feeds/packagefeeds:latest
+docker build . -t gcr.io/ossf-malware-analysis/scheduled-feeds:latest
 ```
-
-## Running the example
-
-```
-docker-compose up -d
-curl localhost:8080
-```
-
-Curling `localhost:8080` will trigger package-feeds to poll it's feeds and send the packages downstream to package-analysis. Outputs can be found at http://localhost:9000/minio/package-analysis,
-using the credentials minio:minio123 for authentication.
-
-`docker-compose logs -f feeds` will provide information on the packages which have been send downstream.
-
-`docker-compose logs -f scheduler` will provide information on the packages which have been received and proxied onto the analysis workers.
-
-`docker-compose logs -f analysis` provides too much stdout to be useful, outputs are sent to minio as mentioned above.

--- a/examples/e2e/docker-compose.yml
+++ b/examples/e2e/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
   feeds:
     restart: "on-failure"
-    image: docker.pkg.github.com/ossf/package-feeds/packagefeeds:latest
+    image: gcr.io/ossf-malware-analysis/scheduled-feeds:latest
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
e2e docs are improved and include suggestions to fix issues that might arrise.

The docker-compose.yml also now points to the gcr.io version of the package-feeds image so it does not require auth.
