### PR TITLE
Fix loader memory consumption issue by add time based partitions

### DIFF
--- a/function/loader/schema.json
+++ b/function/loader/schema.json
@@ -243,7 +243,7 @@
   {
     "mode": "NULLABLE",
     "name": "CreatedTimestamp",
-    "type": "INTEGER"
+    "type": "TIMESTAMP"
   },
   {
     "fields": [


### PR DESCRIPTION
Unfortunately the schema has changed, but the timestamp field will make querying easier.

Signed-off-by: Caleb Brown <calebbrown@google.com>