### PR TITLE
Move logging calls into rundynamic.go and make analysis image exit with error code if analysis fails

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -120,7 +120,7 @@ func main() {
 	lastStatus := results[lastRunPhase].Status
 	if lastStatus != dynamicanalysis.StatusCompleted {
 		log.Fatal("Analysis phase did not complete successfully",
-			log.Label("lastRunPhase", string(lastRunPhase)),
-			log.Label("status", string(lastStatus)))
+			"lastRunPhase", lastRunPhase,
+			"status", lastStatus)
 	}
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -100,12 +100,9 @@ func main() {
 	sb := sandbox.New(manager.Image(), sbOpts...)
 	defer sb.Clean()
 
-	results, lastRunPhase, err := analysis.RunDynamicAnalysis(sb, pkg)
+	results, _, err := analysis.RunDynamicAnalysis(sb, pkg)
 	if err != nil {
-		analysis.LogDynamicAnalysisError(pkg, lastRunPhase, err)
 		log.Fatal("Aborting due to run error", "error", err)
-	} else {
-		analysis.LogDynamicAnalysisResult(pkg, lastRunPhase, results[lastRunPhase].Status)
 	}
 
 	ctx := context.Background()

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -116,6 +116,7 @@ func main() {
 		}
 	}
 
+	// this is only valid if RunDynamicAnalysis() returns nil err
 	lastStatus := results[lastRunPhase].Status
 	if lastStatus != dynamicanalysis.StatusCompleted {
 		log.Fatal("Analysis phase did not complete successfully",

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/ossf/package-analysis/internal/analysis"
+	"github.com/ossf/package-analysis/internal/dynamicanalysis"
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
 	"github.com/ossf/package-analysis/internal/resultstore"
@@ -100,7 +101,7 @@ func main() {
 	sb := sandbox.New(manager.Image(), sbOpts...)
 	defer sb.Clean()
 
-	results, _, err := analysis.RunDynamicAnalysis(sb, pkg)
+	results, lastRunPhase, err := analysis.RunDynamicAnalysis(sb, pkg)
 	if err != nil {
 		log.Fatal("Aborting due to run error", "error", err)
 	}
@@ -113,5 +114,12 @@ func main() {
 			log.Fatal("Failed to upload results to blobstore",
 				"error", err)
 		}
+	}
+
+	lastStatus := results[lastRunPhase].Status
+	if lastStatus != dynamicanalysis.StatusCompleted {
+		log.Fatal("Analysis phase did not complete successfully",
+			log.Label("lastRunPhase", string(lastRunPhase)),
+			log.Label("status", string(lastStatus)))
 	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -130,13 +130,9 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 	sb := sandbox.New(manager.Image(), sbOpts...)
 	defer sb.Clean()
 
-	results, lastRunPhase, err := analysis.RunDynamicAnalysis(sb, pkg)
+	results, _, err := analysis.RunDynamicAnalysis(sb, pkg)
 	if err != nil {
-		analysis.LogDynamicAnalysisError(pkg, lastRunPhase, err)
 		return err
-	} else {
-		// Produce a log message for the final status to help generate metrics.
-		analysis.LogDynamicAnalysisResult(pkg, lastRunPhase, results[lastRunPhase].Status)
 	}
 
 	if resultsBucket != "" {

--- a/internal/analysis/rundynamic.go
+++ b/internal/analysis/rundynamic.go
@@ -45,13 +45,20 @@ func RunDynamicAnalysis(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg) (results Dyna
 		}
 	}
 
+	if err != nil {
+		logDynamicAnalysisError(pkg, lastRunPhase, err)
+	} else {
+		// Produce a log message for the final status to help generate metrics.
+		logDynamicAnalysisResult(pkg, lastRunPhase, results[lastRunPhase].Status)
+	}
+
 	return results, lastRunPhase, err
 }
 
-// LogDynamicAnalysisError indicates some error happened while attempting to run
+// logDynamicAnalysisError indicates some error happened while attempting to run
 // the package code, which was not caused by the package itself. This means it was
 // not possible to analyse the package properly, and the results are invalid.
-func LogDynamicAnalysisError(pkg *pkgecosystem.Pkg, errorPhase pkgecosystem.RunPhase, err error) {
+func logDynamicAnalysisError(pkg *pkgecosystem.Pkg, errorPhase pkgecosystem.RunPhase, err error) {
 	log.Error("Analysis run failed",
 		log.Label("ecosystem", pkg.Ecosystem()),
 		log.Label("name", pkg.Name()),
@@ -60,10 +67,10 @@ func LogDynamicAnalysisError(pkg *pkgecosystem.Pkg, errorPhase pkgecosystem.RunP
 		"error", err)
 }
 
-// LogDynamicAnalysisResult indicates that the package code was run successfully,
+// logDynamicAnalysisResult indicates that the package code was run successfully,
 // and what happened when it was run. This may include errors in the analysis
 // of the package, but not errors in the running itself.
-func LogDynamicAnalysisResult(pkg *pkgecosystem.Pkg, finalPhase pkgecosystem.RunPhase, finalStatus dynamicanalysis.Status) {
+func logDynamicAnalysisResult(pkg *pkgecosystem.Pkg, finalPhase pkgecosystem.RunPhase, finalStatus dynamicanalysis.Status) {
 	ecosystem := pkg.Ecosystem()
 	name := pkg.Name()
 	version := pkg.Version()


### PR DESCRIPTION
Addresses remaining issue in #418, and fixes #406 as a replacement for #420