### PR TITLE
Refactor package resolution logic out of cmd/{worker,analysis}/main.go

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -61,28 +61,13 @@ func main() {
 		log.Label("localPath", *localPkg),
 		log.Label("version", *version))
 
-	var pkg *pkgecosystem.Pkg
-	var err error
-	if *localPkg != "" {
-		if *version != "" {
-			log.Panic("Unable to specify version for local packages")
-		}
-		pkg = manager.Local(*pkgName, *version, *localPkg)
-	} else if *version != "" {
-		pkg = manager.Package(*pkgName, *version)
-	} else {
-		pkg, err = manager.Latest(*pkgName)
-		if err != nil {
-			log.Panic("Failed to get latest version",
-				log.Label("ecosystem", *ecosystem),
-				log.Label("name", *pkgName))
-		}
+	pkg, err := manager.ResolvePackage(*pkgName, *version, *localPkg)
+	if err != nil {
+		log.Panic("Error resolving package",
+			log.Label("ecosystem", *ecosystem),
+			log.Label("name", *pkgName),
+			"error", err)
 	}
-
-	log.Info("Got request",
-		log.Label("ecosystem", *ecosystem),
-		log.Label("name", *pkgName),
-		log.Label("version", *version))
 
 	// Prepare the sandbox:
 	// - Always pass through the tag. An empty tag is the same as "latest".

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -110,21 +110,13 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		sbOpts = append(sbOpts, sandbox.Volume(f.Name(), localPkgPath))
 	}
 
-	var pkg *pkgecosystem.Pkg
-	var err error
-	if localPkgPath != "" {
-		pkg = manager.Local(name, version, localPkgPath)
-	} else if version != "" {
-		pkg = manager.Package(name, version)
-	} else {
-		pkg, err = manager.Latest(name)
-		if err != nil {
-			log.Error("Failed to get latest version",
-				log.Label("ecosystem", ecosystem),
-				log.Label("name", name),
-				"error", err)
-			return err
-		}
+	pkg, err := manager.ResolvePackage(name, version, localPkgPath)
+	if err != nil {
+		log.Error("Error resolving package",
+			log.Label("ecosystem", ecosystem),
+			log.Label("name", name),
+			"error", err)
+		return err
 	}
 
 	sb := sandbox.New(manager.Image(), sbOpts...)

--- a/internal/pkgecosystem/ecosystem.go
+++ b/internal/pkgecosystem/ecosystem.go
@@ -1,6 +1,7 @@
 package pkgecosystem
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -79,6 +80,21 @@ func (p *PkgManager) Package(name, version string) *Pkg {
 		version: version,
 		manager: p,
 	}
+}
+
+func (p *PkgManager) ResolvePackage(name, version, localPath string) (pkg *Pkg, err error) {
+	if localPath != "" {
+		// TODO version should be cross-checked with actual version parsed from package file
+		pkg = p.Local(name, version, localPath)
+	} else if version != "" {
+		pkg = p.Package(name, version)
+	} else {
+		pkg, err = p.Latest(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest version for package %s: %v", name, err)
+		}
+	}
+	return pkg, nil
 }
 
 func normalizePkgName(pkg string) string {


### PR DESCRIPTION
Refactors duplicate logic from `cmd/{worker,analysis}/main.go`, with slight behaviour changes:

1. The analysis version panicked if both a local package and an explicit version were specified on the command line. According to @calebbrown this behaviour is not necessary and can be removed
2. If `manager.Latest` returns a non-nil error, the log message changes from `Failed to get latest version` to `Error resolving package` and the log tags contain a key `"error": "failed to get latest version for package <package name>: <returned error info>"`

Are these acceptable?