### PR TITLE
Fix shellcheck warning in build_docker.sh

### DIFF
--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -3,7 +3,7 @@
 push=${PUSH:-"false"}
 tag=${RELEASE_TAG}
 
-BASE_PATH="$(dirname $(dirname $(realpath $0)))"
+BASE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
 REGISTRY=gcr.io/ossf-malware-analysis
 
 # Mapping from the container name to the path containing the Dockerfile.


### PR DESCRIPTION
Shellcheck was giving a warning that paths should be quoted here