### PR TITLE
Create mapping between file name and bytes written and store in new .…

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -29,6 +29,7 @@ var (
 	listModes     = flag.Bool("list-modes", false, "prints out a list of available analysis modes")
 	analysisMode  = utils.CommaSeparatedFlags("analysis-mode", "dynamic",
 		"single or comma separated list of analysis modes to run. Use -list-modes to see available options")
+	uploadFileWriteInfo = flag.String("upload-file-write-info", "", "bucket path for uploading information from file writes")
 )
 
 func parseBucketPath(path string) (string, string) {
@@ -90,15 +91,23 @@ func dynamicAnalysis(manager *pkgecosystem.PkgManager, pkg *pkgecosystem.Pkg) {
 	ctx := context.Background()
 	if *dynamicUpload != "" {
 		bucket, path := parseBucketPath(*dynamicUpload)
-		err := resultstore.New(bucket, resultstore.BasePath(path)).Save(ctx, pkg, results)
+		err := resultstore.New(bucket, resultstore.BasePath(path)).Save(ctx, pkg, results.StraceSummary)
 		if err != nil {
 			log.Fatal("Failed to upload dynamic analysis results to blobstore",
 				"error", err)
 		}
 	}
 
+	if *uploadFileWriteInfo != "" {
+		bucket, path := parseBucketPath(*uploadFileWriteInfo)
+		err := resultstore.New(bucket, resultstore.BasePath(path)).Save(ctx, pkg, results.FileWrites)
+		if err != nil {
+			log.Fatal("Failed to upload file write analysis results to blobstore", "error", err)
+		}
+	}
+
 	// this is only valid if RunDynamicAnalysis() returns nil err
-	lastStatus := results[lastRunPhase].Status
+	lastStatus := results.StraceSummary[lastRunPhase].Status
 	if lastStatus != analysis.StatusCompleted {
 		log.Fatal("Dynamic analysis phase did not complete successfully",
 			"lastRunPhase", lastRunPhase,

--- a/examples/e2e/docker-compose.yml
+++ b/examples/e2e/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       MINIO_ROOT_PASSWORD: minio123
       MINIO_REGION_NAME: dummy_region
     entrypoint: sh
-    command: -c 'mkdir -p /data/package-analysis && /usr/bin/minio server /data'
+    command: -c 'mkdir -p /data/{package-analysis,package-analysis-file-writes} && /usr/bin/minio server /data'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
@@ -47,6 +47,7 @@ services:
     environment:
       OSSMALWARE_WORKER_SUBSCRIPTION: kafka://worker?topic=workers
       OSSF_MALWARE_ANALYSIS_RESULTS: s3://package-analysis?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
+      OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS: s3://package-analysis-file-writes?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       KAFKA_BROKERS: kafka:9092
       AWS_ACCESS_KEY_ID: minio
       AWS_SECRET_ACCESS_KEY: minio123

--- a/internal/dynamicanalysis/analysis.go
+++ b/internal/dynamicanalysis/analysis.go
@@ -23,6 +23,11 @@ type fileResult struct {
 	Delete bool
 }
 
+type FileWrites struct {
+	Path      string
+	WriteInfo []strace.WriteInfo
+}
+
 type socketResult struct {
 	Address   string
 	Port      int
@@ -44,7 +49,7 @@ type dnsResult struct {
 	Queries []dnsQueries
 }
 
-type Result struct {
+type StraceSummary struct {
 	Status   analysis.Status
 	Stdout   []byte
 	Stderr   []byte
@@ -54,9 +59,16 @@ type Result struct {
 	DNS      []dnsResult
 }
 
-var (
-	resultError = &Result{Status: analysis.StatusErrorOther}
-)
+type Result struct {
+	StraceSummary StraceSummary
+	FileWrites    []FileWrites
+}
+
+var resultError = &Result{
+	StraceSummary: StraceSummary{
+		Status: analysis.StatusErrorOther,
+	},
+}
 
 func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 	log.Info("Running dynamic analysis",
@@ -97,9 +109,11 @@ func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 	}
 
 	result := Result{
-		Status: analysis.StatusForRunResult(r),
-		Stdout: lastLines(r.Stdout(), maxOutputLines, maxOutputBytes),
-		Stderr: lastLines(r.Stderr(), maxOutputLines, maxOutputBytes),
+		StraceSummary: StraceSummary{
+			Status: analysis.StatusForRunResult(r),
+			Stdout: lastLines(r.Stdout(), maxOutputLines, maxOutputBytes),
+			Stderr: lastLines(r.Stderr(), maxOutputLines, maxOutputBytes),
+		},
 	}
 	result.setData(straceResult, dns)
 	return &result, nil
@@ -107,16 +121,19 @@ func Run(sb sandbox.Sandbox, args []string) (*Result, error) {
 
 func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyzer) {
 	for _, f := range straceResult.Files() {
-		d.Files = append(d.Files, fileResult{
+		d.StraceSummary.Files = append(d.StraceSummary.Files, fileResult{
 			Path:   f.Path,
 			Read:   f.Read,
 			Write:  f.Write,
 			Delete: f.Delete,
 		})
+		if len(f.WriteInfo) > 0 {
+			d.FileWrites = append(d.FileWrites, FileWrites{f.Path, f.WriteInfo})
+		}
 	}
 
 	for _, s := range straceResult.Sockets() {
-		d.Sockets = append(d.Sockets, socketResult{
+		d.StraceSummary.Sockets = append(d.StraceSummary.Sockets, socketResult{
 			Address:   s.Address,
 			Port:      s.Port,
 			Hostnames: dns.Hostnames(s.Address),
@@ -124,7 +141,7 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 	}
 
 	for _, c := range straceResult.Commands() {
-		d.Commands = append(d.Commands, commandResult{
+		d.StraceSummary.Commands = append(d.StraceSummary.Commands, commandResult{
 			Command:     c.Command,
 			Environment: c.Env,
 		})
@@ -138,6 +155,6 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 				Types:    types,
 			})
 		}
-		d.DNS = append(d.DNS, c)
+		d.StraceSummary.DNS = append(d.StraceSummary.DNS, c)
 	}
 }

--- a/internal/strace/strace_test.go
+++ b/internal/strace/strace_test.go
@@ -2,6 +2,7 @@ package strace_test
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -40,8 +41,71 @@ func TestParseFileReadThenCreate(t *testing.T) {
 		t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
 	}
 	files := res.Files()
-	if len(files) != 1 || files[0] != want {
+	if len(files) != 1 || !reflect.DeepEqual(files[0], want) {
 		t.Errorf(`Files() = %v, want [%v]`, files, want)
+	}
+}
+
+func TestParseFileWriteMultipleWritesToSameFile(t *testing.T) {
+	input := "I0928 00:18:54.794008     365 strace.go:593] [   6:   6] uname E write(0x1 host:[5], 0x555695ceaab0 \"Linux 4.4.0\\n\", 0xc)\n" +
+		"I1109 06:53:19.688807     950 strace.go:593] [   3:   3] python3 E write(0x1 host:[5], 0x560d2708e7c0 \"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport\"..., 0xe64)"
+	firstFileInfoWant := strace.WriteInfo{
+		BytesWritten: 12,
+	}
+	secondFileInfoWant := strace.WriteInfo{
+		BytesWritten: 3684,
+	}
+	fileInfoWantArray := []strace.WriteInfo{firstFileInfoWant, secondFileInfoWant}
+
+	want := strace.FileInfo{
+		Path:      "host:[5]",
+		Write:     true,
+		WriteInfo: fileInfoWantArray,
+	}
+
+	r := strings.NewReader(input)
+	res, err := strace.Parse(r)
+	if err != nil || res == nil {
+		t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
+	}
+	files := res.Files()
+	if len(files) != 1 || !reflect.DeepEqual(files[0], want) {
+		t.Errorf(`Files() = %v, want %v`, files[0], want)
+	}
+}
+
+func TestParseFileWritesToDifferentFiles(t *testing.T) {
+	input := "I0928 00:18:54.794008     365 strace.go:593] [   6:   6] uname E write(0x1 host:[5], 0x555695ceaab0 \"Linux 4.4.0\\n\", 0xc)\n" +
+		"I1109 06:53:19.688807     950 strace.go:593] [   3:   3] python3 E write(0x1 pipe:[5], 0x560d2708e7c0 \"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport\"..., 0xe64)"
+	firstFileInfo := strace.FileInfo{
+		Path:  "host:[5]",
+		Write: true,
+		WriteInfo: []strace.WriteInfo{
+			{
+				BytesWritten: 12,
+			},
+		},
+	}
+
+	secondFileInfo := strace.FileInfo{
+		Path:  "pipe:[5]",
+		Write: true,
+		WriteInfo: []strace.WriteInfo{
+			{
+				BytesWritten: 3684,
+			},
+		},
+	}
+	want := []strace.FileInfo{firstFileInfo, secondFileInfo}
+
+	r := strings.NewReader(input)
+	res, err := strace.Parse(r)
+	if err != nil || res == nil {
+		t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
+	}
+	files := res.Files()
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf(`Files() = %v, want  = %v`, files, want)
 	}
 }
 
@@ -219,7 +283,7 @@ func TestParseFilesOneEntry(t *testing.T) {
 				t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
 			}
 			files := res.Files()
-			if len(files) != 1 || files[0] != test.want {
+			if len(files) != 1 || !reflect.DeepEqual(files[0], test.want) {
 				t.Errorf(`Files() = %v, want [%v]`, files, test.want)
 			}
 		})

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -7,15 +7,22 @@ import (
 	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
-type DynamicAnalysisResults map[pkgecosystem.RunPhase]*dynamicanalysis.Result
+type DynamicAnalysisStraceSummary map[pkgecosystem.RunPhase]*dynamicanalysis.StraceSummary
+type DynamicAnalysisFileWrites map[pkgecosystem.RunPhase]*[]dynamicanalysis.FileWrites
+type DynamicAnalysisResults struct {
+	StraceSummary DynamicAnalysisStraceSummary
+	FileWrites    DynamicAnalysisFileWrites
+}
 
 /*
 RunDynamicAnalysis runs dynamic analysis on the given package in the sandbox
 provided, across all phases (e.g. import, install) valid in the package ecosystem.
 Status and errors are logged to stdout. There are 3 return values:
 
-results: Map of each successfully run phase to the corresponding dynamic analysis result.
+results: Map of each successfully run phase to a summary of the corresponding dynamic analysis result.
 If error is not nil, then results[lastRunPhase] is nil.
+
+writeResults: Map of each successfully run phase to further dynamic analysis result on file writes. This data will be uploaded to a separate bucket.
 
 lastRunPhase: the last phase that was run. If error is non-nil, this phase did not complete successfully
 and the results for this phase are not recorded. Otherwise, results[lastRunPhase] contains
@@ -24,8 +31,10 @@ the corresponding results this phase, including any abnormal termination of the 
 error: Any error that occurred in the runtime/sandbox infrastructure. This does not include errors caused
 by the package under analysis.
 */
+
 func RunDynamicAnalysis(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg) (results DynamicAnalysisResults, lastRunPhase pkgecosystem.RunPhase, err error) {
-	results = make(DynamicAnalysisResults)
+	straceSummary := make(DynamicAnalysisStraceSummary)
+	fileWrites := make(DynamicAnalysisFileWrites)
 	for _, phase := range pkg.Manager().RunPhases() {
 		result, err := dynamicanalysis.Run(sb, pkg.Command(phase))
 		lastRunPhase = phase
@@ -36,20 +45,24 @@ func RunDynamicAnalysis(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg) (results Dyna
 			break
 		}
 
-		results[phase] = result
+		straceSummary[phase] = &result.StraceSummary
+		fileWrites[phase] = &result.FileWrites
 
-		if result.Status != analysis.StatusCompleted {
+		if result.StraceSummary.Status != analysis.StatusCompleted {
 			// Error caused by an issue with the package (probably).
 			// Don't continue with phases if this one did not complete successfully.
 			break
 		}
 	}
 
+	results.StraceSummary = straceSummary
+	results.FileWrites = fileWrites
+
 	if err != nil {
 		LogDynamicAnalysisError(pkg, lastRunPhase, err)
 	} else {
 		// Produce a log message for the final status to help generate metrics.
-		LogDynamicAnalysisResult(pkg, lastRunPhase, results[lastRunPhase].Status)
+		LogDynamicAnalysisResult(pkg, lastRunPhase, results.StraceSummary[lastRunPhase].Status)
 	}
 
 	return results, lastRunPhase, err

--- a/run_analysis.sh
+++ b/run_analysis.sh
@@ -14,6 +14,7 @@ VERSION="latest"
 PKG_PATH=""
 
 RESULTS_DIR="/tmp/results"
+FILE_WRITE_RESULTS_DIR="/tmp/writeResults"
 LOGS_DIR="/tmp/dockertmp"
 
 # for pretty printing
@@ -26,21 +27,22 @@ function print_usage {
 
 
 function print_package_details {
-	echo "Ecosystem:   $ECOSYSTEM"
-	echo "Package:     $PACKAGE"
-	echo "Version:     $VERSION"
+	echo "Ecosystem:              $ECOSYSTEM"
+	echo "Package:                $PACKAGE"
+	echo "Version:                $VERSION"
 	if [[ $LOCAL -eq 1 ]]; then
 		LOCATION="$PKG_PATH"
 	else
 		LOCATION="remote"
 	fi
 
-	echo "Location:    $LOCATION"
+	echo "Location:               $LOCATION"
 }
 
 function print_results_dirs {
-	echo "Results dir: $RESULTS_DIR"
-	echo "Logs dir:    $LOGS_DIR"
+	echo "Results dir:            $RESULTS_DIR"
+	echo "File Write Results dir: $FILE_WRITE_RESULTS_DIR"
+	echo "Logs dir:               $LOGS_DIR"
 }
 
 
@@ -85,13 +87,14 @@ fi
 
 
 
+
 DOCKER_OPTS=("run" "--cgroupns=host" "--privileged" "-ti")
 
-DOCKER_MOUNTS=("-v" "/var/lib/containers:/var/lib/containers" "-v" "$RESULTS_DIR:/results" "-v" "$LOGS_DIR:/tmp")
+DOCKER_MOUNTS=("-v" "/var/lib/containers:/var/lib/containers" "-v" "$RESULTS_DIR:/results" "-v" "$FILE_WRITE_RESULTS_DIR:/writeResults" "-v" "$LOGS_DIR:/tmp")
 
 ANALYSIS_IMAGE=gcr.io/ossf-malware-analysis/analysis
 
-ANALYSIS_ARGS=("analyze" "-package" "$PACKAGE" "-ecosystem" "$ECOSYSTEM" "-upload" "file:///results/")
+ANALYSIS_ARGS=("analyze" "-package" "$PACKAGE" "-ecosystem" "$ECOSYSTEM" "-upload" "file:///results/" "-upload-file-write-info" "file:///writeResults/")
 
 if [[ "$VERSION" != "latest" ]]; then
 	ANALYSIS_ARGS+=("-version" "$VERSION")
@@ -139,6 +142,7 @@ else
 	sleep 1 # Allow time to read info above before executing
 
 	mkdir -p "$RESULTS_DIR"
+	mkdir -p "$FILE_WRITE_RESULTS_DIR"
 	mkdir -p "$LOGS_DIR"
 
 	docker "${DOCKER_OPTS[@]}" "${DOCKER_MOUNTS[@]}" "$ANALYSIS_IMAGE" "${ANALYSIS_ARGS[@]}"
@@ -161,6 +165,7 @@ else
 	echo
 	print_package_details
 	rmdir --ignore-fail-on-non-empty "$RESULTS_DIR"
+	rmdir --ignore-fail-on-non-empty "$FILE_WRITE_RESULTS_DIR"
 	rmdir --ignore-fail-on-non-empty "$LOGS_DIR"
 fi
 


### PR DESCRIPTION
This PR starts the implementation for saving the analysis for file write syscalls. It creates a mapping between the file name and bytes written to that file and stores it in a new .json file for both local analysis (cmd/analyze) and production (cmd/worker). A future PR will also save the file write buffer contents in separate files. 

This PR also adds two tests for the parsing of the write syscalls. 

