### PR TITLE
JS parser improvements

### DIFF
--- a/internal/staticanalysis/parsing/js/babel-parser.js
+++ b/internal/staticanalysis/parsing/js/babel-parser.js
@@ -184,7 +184,7 @@ function traverseAst(ast) {
 }
 
 function findLiteralsAndIdentifiers(source, printDebug) {
-    const ast = parser.parse(source);
+    const ast = parser.parse(source, { errorRecovery: true });
 
     // walk the AST and print out any literals
     if (printDebug) {

--- a/internal/staticanalysis/parsing/js/babel-parser.js
+++ b/internal/staticanalysis/parsing/js/babel-parser.js
@@ -26,49 +26,116 @@ function logJSON(type, subtype, name, pos, array, extra = null) {
 }
 
 function logIdentifierJSON(subtype, name, pos, extra = null) {
+    if (name === undefined) {
+        console.log("Error: undefined identifier name at pos " + pos);
+        return;
+    }
     logJSON("Identifier", subtype, name, pos, null, extra);
 }
 
+// node is an Identifier node or PrivateName (which has a key attribute holding an Identifier)
+function logIdentifierNodeJSON(subtype, node) {
+    switch (node.type) {
+        case "Identifier":
+            logIdentifierJSON(subtype, node.name, locationString(node));
+            break;
+        case "PrivateName":
+            logIdentifierJSON(subtype, node.id.name, locationString(node.id));
+            break;
+        default:
+            console.log("Error: logIdentifierNodeJSON passed a node of type " + node.type);
+            break;
+    }
+}
+
 function logLiteralJSON(subtype, value, pos, inArray, extra = null) {
+    if (value === undefined) {
+        console.log("Error: undefined literal value at pos " + pos);
+        return;
+    }
     logJSON("Literal", subtype, value, pos, inArray, extra);
 }
 
-function logParameter(p) {
-    if (p === null) {
-        return;
-    }
-    if (p.type === "Identifier") {
-        // simple function parameter name: function f(x)
-        logIdentifierJSON("Parameter", p.name, locationString(p));
-    } else if (p.type === "AssignmentPattern" && p.left.type === "Identifier") {
-        // parameter with default value: function f(x = 3)
-        logIdentifierJSON("Parameter", p.left.name, locationString(p));
+function visitIdentifierOrPrivateName(path) {
+    const node = path.node;
+    const parentNode = path.parentPath.node;
+    const parentParentNode = path.parentPath.parentPath.node;
+
+    switch (parentNode.type) {
+        case "ObjectProperty":
+        // fall through
+            if (node === parentNode.key) {
+                logIdentifierNodeJSON("Variable", node);
+            }
+            break;
+        case "ArrayPattern":
+            logIdentifierNodeJSON("Variable", node);
+            break;
+        case "VariableDeclarator":
+            if (node === parentNode.id) {
+                logIdentifierNodeJSON("Variable", node);
+            }
+            break;
+        case "FunctionDeclaration":
+            if (node === parentNode.id) {
+                logIdentifierNodeJSON("Function", node);
+            } else {
+                logIdentifierNodeJSON("Parameter", node);
+            }
+            break;
+        case "LabeledStatement":
+            logIdentifierNodeJSON("StatementLabel", node);
+            break;
+        case "PrivateName":
+            // processed already
+            break;
+        case "MemberExpression":
+            if (node === parentNode.property) {
+                logIdentifierNodeJSON("Member", node);
+            }
+            break;
+        case "CatchClause":
+            logIdentifierNodeJSON("Parameter", node);
+            break;
+        case "ClassPrivateMethod":
+            // fall through
+        case "ClassMethod":
+            if (node === parentNode.key) {
+                if (parentNode.kind !== "constructor") {
+                    logIdentifierNodeJSON("Method", node);
+                }
+            } else {
+                logIdentifierNodeJSON("Parameter", node);
+            }
+            break;
+        case "ClassPrivateProperty":
+            // fall through
+        case "ClassProperty":
+            logIdentifierNodeJSON("Property", node);
+            break;
+        case "AssignmentPattern":
+            if (node === parentNode.left && parentParentNode.type === "FunctionDeclaration") {
+                // function parameter with default value
+                logIdentifierNodeJSON("Parameter", node);
+            }
+            break;
+        case "AssignmentExpression":
+            if (node === parentNode.left) {
+                logIdentifierNodeJSON("AssignmentTarget", node);
+            }
+            break;
+        case "ClassExpression":
+            logIdentifierNodeJSON("Class", node);
+            break;
     }
 }
 
-function logParameters(node) {
-    for (let p of node.params) {
-        logParameter(p);
-    }
-}
-
-function traverseAst(ast, printDebug = false) {
+function traverseAst(ast) {
     /*
-      The way this function is currently structured, the visitor finds identifiers by visiting every different type
-      of relevant symbol, and then logging the relevant identifier node (e.g. id, label) for that symbol.
-      This structure was kept from the previous switch statement version.
-
-      However, a simpler way to do it would be to just traverse until an actual Identifier node is found,
-      then figure what kind of identifier it is by inverting the logic for each case that currently is here.
-      This should be possible since babel-traverse lets you access parent nodes,
-      and it may simplify the code a little bit.
-
       TODO
-       1. If this code needs to be extended much more, we should switch to the second way above.
-       2. Consider adding state to allow distinction between elements from different arrays
-       3. Consider logging names of decorators
+       1. Consider adding state to allow distinction between elements from different arrays
+       2. Consider logging names of decorators
      */
-
     const arrayVisitor = {
         StringLiteral: function(path) {
             const loc = locationString(path.node);
@@ -85,71 +152,17 @@ function traverseAst(ast, printDebug = false) {
     };
 
     const astVisitor = {
-        FunctionDeclaration: function (path) {
-            if (path.node.id !== null) {
-                logIdentifierJSON("Function", path.node.id.name, locationString(path.node.id));
-            }
-            logParameters(path.node);
-        },
-        AssignmentExpression: function (path) {
-            if (path.node.left.type === "Identifier") {
-                logIdentifierJSON("AssignmentTarget", path.node.left.name, locationString(path.node.left));
-            }
-        },
-        ClassExpression: function (path) {
-            if (path.node.id !== null) {
-                logIdentifierJSON("Class", path.node.id.name, locationString(path.node.id));
-            }
-        },
-        ClassMethod: function (path) {
-            if (path.node.kind !== "Constructor" && path.node.key.type === "Identifier") {
-                logIdentifierJSON("Method", path.node.key.name, locationString(path.node.key));
-            }
-            logParameters(path.node);
-        },
-        ClassPrivateMethod: function (path) {
-            // path.node.key has type PrivateName
-            logIdentifierJSON("Method", path.node.key.id.name, locationString(path.node.key.id));
-            logParameters(path.node);
-        },
-        ClassProperty: function (path) {
-            if (path.node.key.type === "Identifier") {
-                logIdentifierJSON("Property", path.node.key.name, locationString(path.node.key));
-            }
-        },
-        ClassPrivateProperty: function (path) {
-            // path.node.key is PrivateName
-            logIdentifierJSON("Property", path.node.key.id.name, locationString(path.node.key.id));
-        },
-        MemberExpression: function (path) {
-            // Should be either Identifier or PrivateName if static (a.b) property
-            // else Expression if computed (a[b]) property
-            let identifier = null;
-            if (path.node.property.type === "Identifier") {
-                identifier = path.node.property;
-            } else if (path.node.property.type === "PrivateName") {
-                identifier = path.node.property.id;
-            }
-            if (identifier !== null) {
-                logIdentifierJSON("Member", identifier.name, locationString(identifier));
-            }
-        },
-        CatchClause: function(path) {
-            logParameter(path.node.param);
-        },
-        LabeledStatement: function (path) {
-            logIdentifierJSON("StatementLabel", path.node.label.name, locationString(path.node.label));
-        },
-        VariableDeclarator: function (path) {
-            logIdentifierJSON("Variable", path.node.id.name, locationString(path.node.id));
-        },
-        //Identifier: function (path) {
-        //    const loc = locationString(path.node);
-        //    logIdentifierJSON("Unrecognised", path.node.name, loc);
-        //},
+        Identifier: visitIdentifierOrPrivateName,
+        PrivateName: visitIdentifierOrPrivateName,
         StringLiteral: function (path) {
             const loc = locationString(path.node);
             logLiteralJSON("String", path.node.value, loc, false, path.node.extra);
+        },
+        DirectiveLiteral: function (path) {
+            // same as string literal
+            const loc = locationString(path.node);
+            logLiteralJSON("String", path.node.value, loc, false, path.node.extra);
+
         },
         NumericLiteral: function (path) {
             const loc = locationString(path.node);
@@ -182,19 +195,32 @@ function findLiteralsAndIdentifiers(source, printDebug) {
 }
 
 function main() {
-    const printDebug = false;
+    const syntaxErrorExitCode = 33;
+    let printDebug = false;
     // https://github.com/nodejs/help/issues/2663
     // Referencing process.stdin.fd (actually just process.stdin) causes stdin to become nonblocking
     // Therefore running this in a terminal in interactive mode with no file piped into stdin will
     // cause the read to fail with EAGAIN
     // Passing the raw '0' as the fd avoids this issue.
     const sourceFile = process.argv.length >= 3 ? process.argv[2] : 0;
+    if (process.argv[process.argv.length - 1] === "debug") {
+        printDebug = true;
+    }
+
     const sourceCode = fs.readFileSync(sourceFile, "utf8");
     if (printDebug) {
         console.log("Read source:");
         console.log(sourceCode);
     }
-    findLiteralsAndIdentifiers(sourceCode, printDebug);
+    try {
+        findLiteralsAndIdentifiers(sourceCode, printDebug);
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            process.exit(syntaxErrorExitCode);
+        } else {
+            throw(e);
+        }
+    }
 }
 
 main();

--- a/internal/staticanalysis/parsing/js/js_parsing_test.go
+++ b/internal/staticanalysis/parsing/js/js_parsing_test.go
@@ -246,9 +246,60 @@ console.log(Rectangle.name);
 	},
 }
 
+var test6 = jsTestCase{
+	name: "test use strict",
+	inputJs: `
+'use strict';
+console.log("Hello");
+`,
+	want: parsing.ParseResult{
+		Identifiers: []parsing.ParsedIdentifier{
+			{parsing.Member, "log", parsing.TextPosition{3, 8}},
+		},
+		Literals: []parsing.ParsedLiteral[any]{
+			{"String", "string", "use strict", `'use strict'`, false, parsing.TextPosition{2, 0}},
+			{"String", "string", "Hello", `"Hello"`, false, parsing.TextPosition{3, 12}},
+		},
+	},
+}
+
+var test7 = jsTestCase{
+	name: "test exotic assignments",
+	inputJs: `
+let [a, b] = [1, 2];
+let [_, c] = [3, 4];
+var index = 0,
+    completed = 0,
+    {length, width} = 10,
+    cancelled = false;
+`,
+	want: parsing.ParseResult{
+		Identifiers: []parsing.ParsedIdentifier{
+			{parsing.Variable, "a", parsing.TextPosition{2, 5}},
+			{parsing.Variable, "b", parsing.TextPosition{2, 8}},
+			{parsing.Variable, "_", parsing.TextPosition{3, 5}},
+			{parsing.Variable, "c", parsing.TextPosition{3, 8}},
+			{parsing.Variable, "index", parsing.TextPosition{4, 4}},
+			{parsing.Variable, "completed", parsing.TextPosition{5, 4}},
+			{parsing.Variable, "length", parsing.TextPosition{6, 5}},
+			{parsing.Variable, "width", parsing.TextPosition{6, 13}},
+			{parsing.Variable, "cancelled", parsing.TextPosition{7, 4}},
+		},
+		Literals: []parsing.ParsedLiteral[any]{
+			{"Numeric", "float64", 1.0, "1", true, parsing.TextPosition{2, 14}},
+			{"Numeric", "float64", 2.0, "2", true, parsing.TextPosition{2, 17}},
+			{"Numeric", "float64", 3.0, "3", true, parsing.TextPosition{3, 14}},
+			{"Numeric", "float64", 4.0, "4", true, parsing.TextPosition{3, 17}},
+			{"Numeric", "float64", 0.0, "0", false, parsing.TextPosition{4, 12}},
+			{"Numeric", "float64", 0.0, "0", false, parsing.TextPosition{5, 16}},
+			{"Numeric", "float64", 10.0, "10", false, parsing.TextPosition{6, 22}},
+		},
+	},
+}
+
 func TestParseJS(t *testing.T) {
 	const printAllJson = false
-	var tests = []jsTestCase{test1, test2, test3, test4, test5}
+	var tests = []jsTestCase{test1, test2, test3, test4, test5, test6, test7}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/staticanalysis/parsing/parsing_types.go
+++ b/internal/staticanalysis/parsing/parsing_types.go
@@ -67,6 +67,9 @@ func (l ParsedLiteral[T]) String() string {
 }
 
 type ParseResult struct {
+	ValidInput  bool
 	Identifiers []ParsedIdentifier
 	Literals    []ParsedLiteral[any]
 }
+
+var InvalidInput = ParseResult{ValidInput: false}


### PR DESCRIPTION
This PR addresses two problems with the JS parser:
1. It could not handle certain variable declarations such as `let [a, b] = [1, 2];`
2. There was no way to differentiate between internal parser errors and syntax errors in the input to be parsed

For 1. the AST traversal was rewritten in the way anticipated in the comment to `traverseAst()` in the existing version of `babel-parser.js`:

> [A] simpler way to do it would be to just traverse until an actual Identifier node is found,
      then figure what kind of identifier it is by inverting the logic for each case that currently is here.

Additional unit tests have been added to `js_parser_test.go` to cover the additional syntax parsing cases.

For 2. when the parser encounters a syntax error in the JS input, it now exits with a pre-defined exit code (33), and produces no output on stdout or stderr. This exit code is checked for in `js_parser.go`, which allows it to set a flag signifying that the input was not valid JavaScript.