### PR TITLE
More improvements to JS parser

### DIFF
--- a/internal/staticanalysis/parsing/js/js_parsing.go
+++ b/internal/staticanalysis/parsing/js/js_parsing.go
@@ -16,7 +16,6 @@ type parserOutputElement struct {
 	SymbolSubtype string         `json:"subtype"`
 	Data          any            `json:"data"`
 	Pos           [2]int         `json:"pos"`
-	Array         bool           `json:"array"`
 	Extra         map[string]any `json:"extra"`
 }
 
@@ -110,11 +109,9 @@ func ParseJS(parserPath string, filePath string, sourceString string) (result pa
 				GoType:   fmt.Sprintf("%T", element.Data),
 				Value:    element.Data,
 				RawValue: element.Extra["raw"].(string),
-				InArray:  element.Array,
+				InArray:  element.Extra["array"] == true,
 				Pos:      element.Pos,
 			})
-		default:
-			panic(fmt.Errorf("unknown element type for parsed symbol: %s", element.SymbolType))
 		}
 	}
 	return


### PR DESCRIPTION
This PR adds more types information to the JSON output of the JavaScript parser:
1. Code comments
2. Other information (currently just number of characters in input)
3. Syntax errors (optional) 

A future PR will add functionality to read this new information on the Go side.

Related to point 3, the parser can now be configured to be more tolerant of syntax errors during parsing. If enabled, any syntax errors that can be recovered from will be logged in the JSON output, alongside the parsed symbols. A command line flag to enable runtime configuration of this behaviour will be added in a future PR.

Finally, the format of the JSON output by the parser is changed slightly - the `array` key has been moved from the top-level JSON object to inside the `extra` dict, as it is applicable only to literals.