### PR TITLE
Replace old octal format with new octal format, and use t.TempDir() in tests

### DIFF
--- a/internal/staticanalysis/parsing/js/init_parser.go
+++ b/internal/staticanalysis/parsing/js/init_parser.go
@@ -49,7 +49,7 @@ var parserFiles = []parserFile{
 }
 
 func InitParser(installDir string) (ParserConfig, error) {
-	if err := os.MkdirAll(installDir, 0777); err != nil {
+	if err := os.MkdirAll(installDir, 0o777); err != nil {
 		return ParserConfig{}, fmt.Errorf("error creating JS parser directory: %v", err)
 	}
 

--- a/internal/utils/write_file.go
+++ b/internal/utils/write_file.go
@@ -10,12 +10,12 @@ WriteFile writes the given file contents to the given path.
 The file may optionally be marked as executable.
 */
 func WriteFile(path string, contents []byte, executable bool) error {
-	if err := os.WriteFile(path, contents, 0666); err != nil {
+	if err := os.WriteFile(path, contents, 0o666); err != nil {
 		return err
 	}
 
 	if executable {
-		if err := os.Chmod(path, 0777); err != nil {
+		if err := os.Chmod(path, 0o777); err != nil {
 			return fmt.Errorf("could not set exec permissions on %s: %v", path, err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Max Fisher <maxfisher@google.com>