### PR TITLE
Revolutionise Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,125 @@
-REGISTRY=gcr.io/ossf-malware-analysis
+# This Makefile contains common development / build commands for Package Analysis. For everything to work properly, it needs to be kept in the top-level project directory.
 
-.PHONY: all all_docker analysis_docker check_scripts run static_analysis_sandbox
+# outermost abspath removes the trailing slash from the directory path
+PREFIX := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+SANDBOX_DIR := $(PREFIX)/sandboxes
 
-all: build_dynamic_analysis_all
+REGISTRY := gcr.io/ossf-malware-analysis
+NODE_IMAGE_NAME := node
+PYTHON_IMAGE_NAME := python
+RUBY_IMAGE_NAME := ruby
+PACKAGIST_IMAGE_NAME := packagist
+CRATES_IMAGE_NAME := crates.io
+STATIC_ANALYSIS_IMAGE_NAME := static-analysis
 
-# This builds everything except the static analysis sandbox
-build_dynamic_analysis_all:
+#
+# This is just the old 'build everything script'
+#
+.PHONY: legacy_build_docker
+legacy_build_docker:
 	bash build/build_docker.sh
 
-# This builds just the local analysis/worker image
-build_local_worker:
-	docker build -t ${REGISTRY}/analysis -f cmd/analyze/Dockerfile .
+.PHONY: all
+all: docker_build_all
 
-# This builds just the static analysis container image
-build_static_analysis_sandbox:
-	docker build -t ${REGISTRY}/static-analysis -f sandboxes/staticanalysis/Dockerfile .
+#
+# These recipes build all the docker images via a common
+# pattern recipe 'docker_build_%'
+# TODO grab release tag from env vars
 
-build_dynamic_analysis_sandboxes:
+docker_build_%:
+	docker build -t ${REGISTRY}/$(IMAGE_NAME) -f $(DOCKERFILE) $(DIR)
 
-# This updates the local sandbox image to use when running local static analysis
-# Ensure 'nopull' is passed to run_analysis.sh
-sync_static_analysis_sandbox_locally:
-	sudo buildah pull docker-daemon:${REGISTRY}/static-analysis:latest
+docker_build_analysis_image: DIR=$(PREFIX)
+docker_build_analysis_image: DOCKERFILE=$(PREFIX)/cmd/analyze/Dockerfile
+docker_build_analysis_image: IMAGE_NAME=analysis
 
-# This updates the local sandbox images to use when running local dynamic analysis
-# Ensure 'nopull' is passed to run_analysis.sh
-sync_dynamic_analysis_sandboxes_locally:
-	sudo buildah pull docker-daemon:${REGISTRY}/node:latest
-	sudo buildah pull docker-daemon:${REGISTRY}/python:latest
-	sudo buildah pull docker-daemon:${REGISTRY}/ruby:latest
-	sudo buildah pull docker-daemon:${REGISTRY}/packagist:latest
-	sudo buildah pull docker-daemon:${REGISTRY}/crates.io:latest
+docker_build_scheduler_image: DIR=$(PREFIX)
+docker_build_scheduler_image: DOCKERFILE=$(PREFIX)/cmd/scheduler/Dockerfile
+docker_build_scheduler_image: IMAGE_NAME=scheduler
 
+docker_build_node_sandbox: DIR=$(SANDBOX_DIR)/npm
+docker_build_node_sandbox: DOCKERFILE=$(SANDBOX_DIR)/npm/Dockerfile
+docker_build_node_sandbox: IMAGE_NAME=$(NODE_IMAGE_NAME)
 
+docker_build_python_sandbox: DIR=$(SANDBOX_DIR)/pypi
+docker_build_python_sandbox: DOCKERFILE=$(SANDBOX_DIR)/pypi/Dockerfile
+docker_build_python_sandbox: IMAGE_NAME=$(PYTHON_IMAGE_NAME)
+
+docker_build_ruby_sandbox: DIR=$(SANDBOX_DIR)/rubygems
+docker_build_ruby_sandbox: DOCKERFILE=$(SANDBOX_DIR)/rubygems/Dockerfile
+docker_build_ruby_sandbox: IMAGE_NAME=$(RUBY_IMAGE_NAME)
+
+docker_build_packagist_sandbox: DIR=$(SANDBOX_DIR)/packagist
+docker_build_packagist_sandbox: DOCKERFILE=$(SANDBOX_DIR)/packagist/Dockerfile
+docker_build_packagist_sandbox:	IMAGE_NAME=$(PACKAGIST_IMAGE_NAME)
+
+docker_build_crates_sandbox: DIR=$(SANDBOX_DIR)/crates.io
+docker_build_crates_sandbox: DOCKERFILE=$(SANDBOX_DIR)/crates.io/Dockerfile
+docker_build_crates_sandbox: IMAGE_NAME=$(CRATES_IMAGE_NAME)
+
+docker_build_static_analysis_sandbox: DIR=$(PREFIX)
+docker_build_static_analysis_sandbox: DOCKERFILE=$(SANDBOX_DIR)/staticanalysis/Dockerfile
+docker_build_static_analysis_sandbox: IMAGE_NAME=$(STATIC_ANALYSIS_IMAGE_NAME)
+
+docker_build_all_sandboxes: docker_build_node_sandbox docker_build_python_sandbox docker_build_ruby_sandbox docker_build_packagist_sandbox docker_build_crates_sandbox docker_build_static_analysis_sandbox
+
+docker_build_all: docker_build_all_sandboxes docker_build_analysis_image docker_build_scheduler_image
+
+#
+# These recipes update (sync) sandbox images built locally by Docker
+# to podman, which is what actually runs them. This is needed for
+# local analyses; in order to use these updated images, pass
+# 'nopull' to run_analysis.sh
+#
+
+sync_%_sandbox:
+	sudo buildah pull docker-daemon:${REGISTRY}/${IMAGE_NAME}:latest
+
+sync_node_sandbox: IMAGE_NAME=${NODE_IMAGE_NAME}
+
+sync_python_sandbox: IMAGE_NAME=${PYTHON_IMAGE_NAME}
+
+sync_ruby_sandbox: IMAGE_NAME=${RUBY_IMAGE_NAME}
+
+sync_packagist_sandbox: IMAGE_NAME=${PACKAGIST_IMAGE_NAME}
+
+sync_crates_sandbox: IMAGE_NAME=${CRATES_IMAGE_NAME}
+
+sync_sandbox_static_analysis: IMAGE_NAME=${STATIC_ANALYSIS_IMAGE_NAME}
+
+sync_all_sandboxes: sync_node_sandbox sync_python_sandbox sync_ruby_sandbox sync_packagist_sandbox sync_crates_sandbox sync_static_analysis_sandbox
+
+#
+# This runs a lint check on all shell scripts in the repo
+#
+.PHONY: check_scripts
 check_scripts:
 	find -type f -name '*.sh' | xargs --no-run-if-empty shellcheck -S warning
 
+.PHONY: run
 run:
 	@echo "To perform a local analysis, please use ./run_analysis.sh"
 	@echo
 
+#
+# These recipes control docker-compose, which is used for
+# end-to-end testing of the complete scheduler/worker system
+#
+.PHONY: docker_compose_start
+docker_compose_start:
+	cd ./examples/e2e && docker-compose up -d
+	sleep 3
+	curl localhost:8080
+	@echo
+	@echo "To see analysis results, go to http://localhost:9000/minio/package-analysis"
+	@echo "Remember to run `make docker_compose_stop` when done!"
+
+.PHONY: docker_compose_logs
+docker_compose_logs:
+	cd ./examples/e2e && docker-compose logs
+
+.PHONY: docker_compose_stop
+docker_compose_stop:
+	cd ./examples/e2e && docker-compose down
 

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,10 @@ sync_packagist_sandbox: IMAGE_NAME=${PACKAGIST_IMAGE_NAME}
 
 sync_crates_sandbox: IMAGE_NAME=${CRATES_IMAGE_NAME}
 
-sync_sandbox_static_analysis: IMAGE_NAME=${STATIC_ANALYSIS_IMAGE_NAME}
+sync_static_analysis_sandbox: IMAGE_NAME=${STATIC_ANALYSIS_IMAGE_NAME}
 
 sync_all_sandboxes: sync_node_sandbox sync_python_sandbox sync_ruby_sandbox sync_packagist_sandbox sync_crates_sandbox sync_static_analysis_sandbox
+
 
 #
 # This runs a lint check on all shell scripts in the repo


### PR DESCRIPTION
This PR makes the following improvements to the Makefile

1. Standardises recipe names
2. Adds building of container and sandbox images
3. Adds buildah commands to sync locally built sandbox images to podman
4. Adds docker compose commands for e2e testing

There is still some remaining logic left over from the `build/build_docker.sh` script to bring over, in particular pushing of built images and adding a release tag if one is defined in the environment variables

Signed-off-by: Max Fisher <maxfisher@google.com>