### PR TITLE
fix minor flaws in static analysis data flow

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -130,9 +130,7 @@ func staticAnalysis(pkg *pkgecosystem.Pkg) {
 		log.Fatal("Static analysis aborted", "error", err)
 	}
 
-	for task, result := range results {
-		fmt.Printf("%s result\n%s\n", task, result)
-	}
+	fmt.Printf("\nResults\n%s\n", results)
 
 	ctx := context.Background()
 	if *staticUpload != "" {

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -1,31 +1,34 @@
 package worker
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
 	"github.com/ossf/package-analysis/internal/sandbox"
 	"github.com/ossf/package-analysis/internal/staticanalysis"
+	"github.com/ossf/package-analysis/internal/utils"
 )
-
-type StaticAnalysisResults map[staticanalysis.Task]any
 
 const staticAnalyzeBinary = "/usr/local/bin/staticanalyze"
 
-func RunStaticAnalyses(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg, tasks ...staticanalysis.Task) (results StaticAnalysisResults, err error) {
+func RunStaticAnalyses(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg, tasks ...staticanalysis.Task) (json.RawMessage, error) {
 	if len(tasks) == 0 {
 		tasks = staticanalysis.AllTasks()
 	}
 
-	log.Info("Running static analysis tasks",
-		"tasks", tasks)
+	log.Info("Running static analysis tasks", "tasks", tasks)
+
+	analyses := utils.Transform(tasks, func(t staticanalysis.Task) string { return string(t) })
 
 	args := []string{
 		staticAnalyzeBinary,
 		"-ecosystem", pkg.EcosystemName(),
 		"-package", pkg.Name(),
 		"-version", pkg.Version(),
+		"-analyses", strings.Join(analyses, ","),
 	}
 
 	if pkg.IsLocal() {
@@ -33,13 +36,9 @@ func RunStaticAnalyses(sb sandbox.Sandbox, pkg *pkgecosystem.Pkg, tasks ...stati
 	}
 
 	r, err := sb.Run(args...)
-
 	if err != nil {
 		return nil, fmt.Errorf("sandbox failed (%w)", err)
 	}
-	results = make(StaticAnalysisResults)
 
-	results[staticanalysis.ObfuscationDetection] = r.Stdout()
-
-	return results, err
+	return r.Stdout(), nil
 }

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -25,7 +25,7 @@ var (
 	version     = flag.String("version", "", "Package version (ignored if local file is specified)")
 	localFile   = flag.String("local", "", "Local package archive containing package to be analysed. Name must match -package argument")
 	help        = flag.Bool("help", false, "Prints this help and list of available analyses")
-	analyses    = utils.CommaSeparatedFlags("analyses", "obfuscation", "comma-separated list of static analyses to perform")
+	analyses    = utils.CommaSeparatedFlags("analyses", "", "comma-separated list of static analyses to perform")
 )
 
 type workDirs struct {
@@ -58,7 +58,7 @@ func checkAnalyses(names []string) ([]staticanalysis.Task, error) {
 func printAnalyses() {
 	fmt.Fprintln(os.Stderr, "Available analyses are:")
 	for _, task := range staticanalysis.AllTasks() {
-		fmt.Fprintln(os.Stderr, "\t", task)
+		fmt.Fprintln(os.Stderr, task)
 	}
 }
 
@@ -220,12 +220,12 @@ func run() (err error) {
 
 	jsonResult, err := json.Marshal(results)
 	if err != nil {
-		log.Error("JSON marshal error", "error", err)
-	} else {
-		fmt.Printf("%v\n", string(jsonResult))
+		return fmt.Errorf("JSON marshall error: %v", err)
 	}
 
-	return err
+	fmt.Printf("%s\n", string(jsonResult))
+
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
This PR fixes some minor issues with the static analysis data flow. In particular:

1. JSON data from the sandboxed staticanalyze binary was being returned as bytes and then re-encoded into a base64 JSON string.
2. The format of the JSON saved to the static analysis bucket contained a redundant nested dictionary with `"obfuscation"` as the key

Signed-off-by: Max Fisher <maxfisher@google.com>