### PR TITLE
Add separate exported types for source code tokens

### DIFF
--- a/internal/staticanalysis/obfuscation/compute_signals.go
+++ b/internal/staticanalysis/obfuscation/compute_signals.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/stats"
 	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/stringentropy"
+	"github.com/ossf/package-analysis/internal/staticanalysis/token"
+	"github.com/ossf/package-analysis/internal/utils"
 )
 
 // characterAnalysis performs analysis on a collection of string symbols, returning:
@@ -46,11 +48,14 @@ TODO Planned signals
 */
 func ComputeSignals(rawData RawData) Signals {
 	signals := Signals{}
-	signals.StringLengthSummary, signals.StringEntropySummary, signals.CombinedStringEntropy =
-		characterAnalysis(rawData.StringLiterals)
 
+	literals := utils.Transform(rawData.StringLiterals, func(s token.String) string { return s.Value })
+	signals.StringLengthSummary, signals.StringEntropySummary, signals.CombinedStringEntropy =
+		characterAnalysis(literals)
+
+	identifierNames := utils.Transform(rawData.Identifiers, func(i token.Identifier) string { return i.Name })
 	signals.IdentifierLengthSummary, signals.IdentifierEntropySummary, signals.CombinedIdentifierEntropy =
-		characterAnalysis(rawData.Identifiers)
+		characterAnalysis(identifierNames)
 
 	return signals
 }

--- a/internal/staticanalysis/obfuscation/data.go
+++ b/internal/staticanalysis/obfuscation/data.go
@@ -5,14 +5,15 @@ import (
 	"strings"
 
 	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/stats"
+	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
 
 type RawData struct {
-	Identifiers    []string
-	StringLiterals []string
-	IntLiterals    []int
-	FloatLiterals  []float64
-	Comments       []string
+	Identifiers    []token.Identifier
+	StringLiterals []token.String
+	IntLiterals    []token.Int
+	FloatLiterals  []token.Float
+	Comments       []token.Comment
 }
 
 type Signals struct {
@@ -48,8 +49,8 @@ type AnalysisResult struct {
 
 func (rd RawData) String() string {
 	parts := []string{
-		fmt.Sprintf("Identifiers\n%s", strings.Join(rd.Identifiers, "\n")),
-		fmt.Sprintf("String Literals\n%s", strings.Join(rd.StringLiterals, "\n")),
+		fmt.Sprintf("Identifiers\n%v", rd.Identifiers),
+		fmt.Sprintf("String Literals\n%v", rd.StringLiterals),
 		fmt.Sprintf("Integer Literals\n%v", rd.IntLiterals),
 		fmt.Sprintf("Float Literals\n%v", rd.FloatLiterals),
 	}

--- a/internal/staticanalysis/token/tokens.go
+++ b/internal/staticanalysis/token/tokens.go
@@ -1,0 +1,27 @@
+package token
+
+import "github.com/ossf/package-analysis/internal/staticanalysis/parsing"
+
+type Identifier struct {
+	Name string
+	Type parsing.IdentifierType
+}
+
+type Comment struct {
+	Value string
+}
+
+type String struct {
+	Value string
+	Raw   string
+}
+
+type Int struct {
+	Value int64
+	Raw   string
+}
+
+type Float struct {
+	Value float64
+	Raw   string
+}


### PR DESCRIPTION
This PR introduces separate exported types for the tokens parsed from package source code, which allows decoupling of the internal parser datatypes from what will be exported externally.

As of this PR, the material enhancement gained from this change is that the raw source code string representing each parsed literal can be included in the raw data, along with the actual literal value. This allows seeing usage of e.g. hexadecimal literals or escape characters in the source code.

Future PRs will add more data to these types.

Signed-off-by: Max Fisher <maxfisher@google.com>