### PR TITLE
Add line length counts to obfuscation.RawData

### DIFF
--- a/internal/staticanalysis/linelengths/line_lengths.go
+++ b/internal/staticanalysis/linelengths/line_lengths.go
@@ -17,6 +17,10 @@ part of the separator.
 
 If filePath is not empty, the function attempts to count the lines of the file
 at that path, otherwise lines in sourceString are counted.
+
+Note: there may not be much useful information to be gathered by distinguishing
+between line lengths when they get very long. It may be pragmatic to just report
+all lines above e.g. 64K as 64K long
 */
 func GetLineLengths(filePath string, sourceString string) (map[int]int, error) {
 	var reader *bufio.Reader
@@ -34,6 +38,11 @@ func GetLineLengths(filePath string, sourceString string) (map[int]int, error) {
 
 	lengths := map[int]int{}
 	for {
+		/* Normally bufio.Scanner would be more convenient to use here, however by default
+		it uses a fixed maximum buffer size (MaxScanTokenSize = 64 * 1024). Since some
+		(obfuscated) source code may contain very long lines, rather than doing our own
+		buffer management we'll use reader.ReadStrings, which uses an internal function
+		(collectFragments) to aggregate multiple full buffers. */
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil && readErr != io.EOF {
 			return nil, readErr

--- a/internal/staticanalysis/linelengths/line_lengths_test.go
+++ b/internal/staticanalysis/linelengths/line_lengths_test.go
@@ -1,0 +1,72 @@
+package linelengths
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSourceStringLineLengths(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		want    map[int]int
+		wantErr bool
+	}{
+		{
+			name: "test simple multiline",
+			source: `
+One
+Two
+Three
+Four
+Five
+`,
+			want:    map[int]int{0: 1, 3: 2, 4: 2, 5: 1},
+			wantErr: false,
+		},
+		{
+			name:    "test simple single line",
+			source:  `One Two Three Four Five`,
+			want:    map[int]int{23: 1},
+			wantErr: false,
+		},
+		{
+			name:    "test empty string",
+			source:  ``,
+			want:    map[int]int{0: 1},
+			wantErr: false,
+		},
+		{
+			name:    "test single char",
+			source:  "a",
+			want:    map[int]int{1: 1},
+			wantErr: false,
+		},
+		{
+			name: "test empty newline",
+			source: `
+`,
+			want:    map[int]int{0: 1},
+			wantErr: false,
+		},
+
+		{
+			name:    "test carriage return",
+			source:  "\r\n",
+			want:    map[int]int{0: 1},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetLineLengths("", tt.source)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLineLengths() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLineLengths() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/staticanalysis/obfuscation/collect_data.go
+++ b/internal/staticanalysis/obfuscation/collect_data.go
@@ -2,8 +2,10 @@ package obfuscation
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
+	"github.com/ossf/package-analysis/internal/staticanalysis/linelengths"
 	"github.com/ossf/package-analysis/internal/staticanalysis/parsing/js"
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
@@ -31,18 +33,23 @@ TODO planned data
 func CollectData(parserConfig js.ParserConfig, jsSourceFile string, jsSourceString string, printDebug bool) (*RawData, error) {
 	parseResult, parserOutput, err := js.ParseJS(parserConfig, jsSourceFile, jsSourceString)
 	if printDebug {
-		println("\nRaw JSON:\n", parserOutput)
+		fmt.Fprintf(os.Stderr, "\nRaw JSON:\n%s\n", parserOutput)
 	}
 	if err != nil {
-		fmt.Printf("Error occured while reading %s: %v\n", jsSourceFile, err)
 		return nil, err
 	}
 	if !parseResult.ValidInput {
 		return nil, nil
 	}
 
+	lineLengths, err := linelengths.GetLineLengths(jsSourceFile, jsSourceString)
+	if err != nil {
+		return nil, err
+	}
+
 	// Initialise with empty slices to avoid null values in JSON
 	data := RawData{
+		LineLengths:    lineLengths,
 		Identifiers:    []token.Identifier{},
 		StringLiterals: []token.String{},
 		IntLiterals:    []token.Int{},

--- a/internal/staticanalysis/obfuscation/data.go
+++ b/internal/staticanalysis/obfuscation/data.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
 
-type RawData struct {
+type RawData struct { // TODO rename to FileData
+	LineLengths    map[int]int
 	Identifiers    []token.Identifier
 	StringLiterals []token.String
 	IntLiterals    []token.Int
@@ -49,10 +50,11 @@ type AnalysisResult struct {
 
 func (rd RawData) String() string {
 	parts := []string{
-		fmt.Sprintf("Identifiers\n%v", rd.Identifiers),
-		fmt.Sprintf("String Literals\n%v", rd.StringLiterals),
-		fmt.Sprintf("Integer Literals\n%v", rd.IntLiterals),
-		fmt.Sprintf("Float Literals\n%v", rd.FloatLiterals),
+		fmt.Sprintf("line lengths\n%v\n", rd.LineLengths),
+		fmt.Sprintf("identifiers\n%v\n", rd.Identifiers),
+		fmt.Sprintf("string literals\n%v\n", rd.StringLiterals),
+		fmt.Sprintf("integer literals\n%v\n", rd.IntLiterals),
+		fmt.Sprintf("float literals\n%v\n", rd.FloatLiterals),
 	}
 	return strings.Join(parts, "\n-------------------\n")
 }


### PR DESCRIPTION
This PR adds data relating to lengths of each line of source code to the `obfuscation.RawData` struct. This data is useful because obfuscated source sometimes consists of very long lines of code, with the special case of everything being on one line

Signed-off-by: Max Fisher <maxfisher@google.com>