### PR TITLE
obfuscation improvements

### DIFF
--- a/internal/staticanalysis/obfuscation/collect_data.go
+++ b/internal/staticanalysis/obfuscation/collect_data.go
@@ -11,10 +11,13 @@ import (
 )
 
 /*
-CollectData parses the given JavaScript input (source file or raw source string) and records raw data
-which is needed for processing by ComputeSignals. To parse a file, specify its path using jsSourceFile.
-In this case, the value of jsSourceString is ignored. If jsSourceFile is empty, then jsSourceString
-is parsed directly as JavaScript code. The input is assumed to be valid JavaScript source.
+CollectData parses the given JavaScript input (source file or raw source string) and
+produces a FileData object capturing data about the source code. This data can be
+further analysed by ComputeSignals.
+
+To parse a file, specify its path using jsSourceFile; the value of jsSourceString is ignored.
+If jsSourceFile is empty, then jsSourceString is parsed directly as JavaScript code.
+The input is assumed to be valid JavaScript source.
 
 If a syntax error is found, a nil pointer is returned with no error. This indicates that
 the file may not be JavaScript and could be parsed using other methods.
@@ -22,15 +25,8 @@ the file may not be JavaScript and could be parsed using other methods.
 In Javascript, there is little distinction between integer and floating point literals - they are
 all parsed as floating point. This function will record a numeric literal as an integer if it can be
 converted to an integer using strconv.Atoi(), otherwise it will be recorded as a floating point literal.
-
-Current data collected:
-  - list of identifiers (e.g. variable, function, and class names, loop labels)
-  - lists of string, integer and floating point literals
-
-TODO planned data
-  - recording of arrays of either string literals or numeric data
 */
-func CollectData(parserConfig js.ParserConfig, jsSourceFile string, jsSourceString string, printDebug bool) (*RawData, error) {
+func CollectData(parserConfig js.ParserConfig, jsSourceFile string, jsSourceString string, printDebug bool) (*FileData, error) {
 	parseResult, parserOutput, err := js.ParseJS(parserConfig, jsSourceFile, jsSourceString)
 	if printDebug {
 		fmt.Fprintf(os.Stderr, "\nRaw JSON:\n%s\n", parserOutput)
@@ -48,7 +44,7 @@ func CollectData(parserConfig js.ParserConfig, jsSourceFile string, jsSourceStri
 	}
 
 	// Initialise with empty slices to avoid null values in JSON
-	data := RawData{
+	data := FileData{
 		LineLengths:    lineLengths,
 		Identifiers:    []token.Identifier{},
 		StringLiterals: []token.String{},

--- a/internal/staticanalysis/obfuscation/collect_data_test.go
+++ b/internal/staticanalysis/obfuscation/collect_data_test.go
@@ -12,7 +12,7 @@ import (
 type testCase struct {
 	name         string
 	jsSource     string
-	expectedData RawData
+	expectedData FileData
 }
 
 var test1 = testCase{
@@ -20,7 +20,7 @@ var test1 = testCase{
 	jsSource: `
 var a = "hello"
 	`,
-	expectedData: RawData{
+	expectedData: FileData{
 		Identifiers: []token.Identifier{
 			{Name: "a", Type: token.Variable},
 		},
@@ -45,7 +45,7 @@ function test(a, b = 2) {
 	}
 }
 	`,
-	expectedData: RawData{
+	expectedData: FileData{
 		Identifiers: []token.Identifier{
 			{Name: "test", Type: token.Function},
 			{Name: "a", Type: token.Parameter},

--- a/internal/staticanalysis/obfuscation/compute_signals_test.go
+++ b/internal/staticanalysis/obfuscation/compute_signals_test.go
@@ -36,7 +36,7 @@ func compareCounts(t *testing.T, name string, expected, actual map[int]int) {
 	}
 }
 
-func testSignals(t *testing.T, signals Signals, stringLiterals []token.String, identifiers []token.Identifier) {
+func testSignals(t *testing.T, signals FileSignals, stringLiterals []token.String, identifiers []token.Identifier) {
 	literals := utils.Transform(stringLiterals, func(s token.String) string { return s.Value })
 	identifierNames := utils.Transform(identifiers, func(i token.Identifier) string { return i.Name })
 	expectedStringEntropySummary := symbolEntropySummary(literals)

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -73,8 +73,8 @@ func doObfuscationDetection(workDirs workDirs) (*obfuscation.AnalysisResult, err
 	}
 
 	result := &obfuscation.AnalysisResult{
-		FileRawData:   map[string]obfuscation.RawData{},
-		FileSignals:   map[string]obfuscation.Signals{},
+		FileData:      map[string]obfuscation.FileData{},
+		FileSignals:   map[string]obfuscation.FileSignals{},
 		ExcludedFiles: []string{},
 		FileSizes:     map[string]int64{},
 	}
@@ -84,7 +84,7 @@ func doObfuscationDetection(workDirs workDirs) (*obfuscation.AnalysisResult, err
 		}
 		if f.Type().IsRegular() {
 			pathInArchive := strings.TrimPrefix(path, workDirs.extractDir+string(os.PathSeparator))
-			log.Debug("Processing " + pathInArchive)
+			log.Info("Processing " + pathInArchive)
 			fileInfo, err := f.Info()
 			if err != nil {
 				log.Error("Error getting file metadata", "filename", pathInArchive, "error", err)
@@ -102,9 +102,10 @@ func doObfuscationDetection(workDirs workDirs) (*obfuscation.AnalysisResult, err
 				result.ExcludedFiles = append(result.ExcludedFiles, pathInArchive)
 			} else {
 				// rawData != nil, err == nil
-				result.FileRawData[f.Name()] = *rawData
+				result.FileData[f.Name()] = *rawData
 				signals := obfuscation.ComputeSignals(*rawData)
-				result.FileSignals[f.Name()] = obfuscation.RemoveNaNs(signals)
+				obfuscation.RemoveNaNs(&signals)
+				result.FileSignals[f.Name()] = signals
 			}
 		}
 		return nil


### PR DESCRIPTION
This PR does the following

- add detection of suspicious identifier names to signals. Currently this checks for identifier names that look like hex strings (#535) or just numeric with one prefix letter
- add crude detection of base64 strings. False positives are reduced by enforcing a minimum valid length for the string (currently 12 characters) and checking for existence of both a digit and a non-hex letter in the string. This detection may need to be improved to further reduce false positives
- improve naming of result struct fields: `Signals` -> `FileSignals`, `RawData` -> `FileData`
- improve comments

Signed-off-by: Max Fisher <maxfisher@google.com>