### PR TITLE
Base64 detection improvements

### DIFF
--- a/internal/staticanalysis/obfuscation/base64/base64_detect.go
+++ b/internal/staticanalysis/obfuscation/base64/base64_detect.go
@@ -1,0 +1,60 @@
+package base64
+
+import (
+	"regexp"
+)
+
+var (
+	// Adapted from https://stackoverflow.com/a/5885097 to only match base64 strings with at least 12 characters
+	base64Regex = regexp.MustCompile("(?:[A-Za-z0-9+/]{4}){3,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})")
+
+	filterRegexes = []*regexp.Regexp{
+		// non-hex letter
+		regexp.MustCompile("[G-Zg-z]"),
+		// uppercase letter
+		regexp.MustCompile("[A-Z]"),
+		// lowercase letter
+		regexp.MustCompile("[a-z]"),
+	}
+)
+
+/*
+looksLikeActualBase64 uses some regex based heuristics to avoid false positive matching
+of long words, hex strings, file paths, etc. as base64 strings, by checking that the
+candidate string matches the regexes defined above
+*/
+func looksLikeActualBase64(candidate string) bool {
+	for _, r := range filterRegexes {
+		if !r.MatchString(candidate) {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+FindBase64Substrings returns a slice containing all the non-overlapping substrings of s
+that are at least 12 characters long, and look like base64-encoded data. The function
+uses regex-based heuristics to determine valid substrings but does not decode the data.
+In particular, valid strings must have only valid base64 characters ([A-Za-z0-9+/]),
+and have correct padding ('=') chars. Additionally, the following heuristics are used:
+
+1. Valid strings contain one letter outside a-f (or A-F). This filters out hex literals.
+2. Valid strings contain one uppercase letter and one lowercase letter
+
+With a moderate sized input string, there will likely be some false positive matches.
+Due to the 12 character minimum length, however, it is highly unlikely that a legitimate
+base64 string will be excluded from the output. Additionally, if there are multiple
+base64 encoded strings in the input, depending on how they are separated, they may
+end up being concatenated together in a single element of the returned string slice.
+*/
+func FindBase64Substrings(s string) []string {
+	matches := []string{}
+
+	for _, candidate := range base64Regex.FindAllString(s, -1) {
+		if looksLikeActualBase64(s) {
+			matches = append(matches, candidate)
+		}
+	}
+	return matches
+}

--- a/internal/staticanalysis/obfuscation/base64/base64_detect.go
+++ b/internal/staticanalysis/obfuscation/base64/base64_detect.go
@@ -2,51 +2,67 @@ package base64
 
 import (
 	"regexp"
+	"strings"
 )
 
 var (
-	// Adapted from https://stackoverflow.com/a/5885097 to only match base64 strings with at least 12 characters
-	base64Regex = regexp.MustCompile("(?:[A-Za-z0-9+/]{4}){3,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})")
+	// RFC4648 standard base 64 chars, padding optional, min length 16
+	standardBase64 = regexp.MustCompile("[[:alnum:]+/]{16,}(?:={0,2})?")
+	// RFC4648 url/file-safe base 64 chars, padding optional, min length 16
+	urlSafeBase64 = regexp.MustCompile("[[:alnum:]-_]{16,}(?:={0,2})?")
+
+	// Combines RFC4648 standard ('+', '/') + file-safe ('-', '_') base 64 variants
+	base64Regex = regexp.MustCompile(standardBase64.String() + "|" + urlSafeBase64.String())
 
 	filterRegexes = []*regexp.Regexp{
-		// non-hex letter
-		regexp.MustCompile("[G-Zg-z]"),
-		// uppercase letter
-		regexp.MustCompile("[A-Z]"),
-		// lowercase letter
-		regexp.MustCompile("[a-z]"),
+		regexp.MustCompile("[[:upper:]]"),
+		regexp.MustCompile("[[:lower:]]"),
+		regexp.MustCompile("[G-Zg-z]"), // non-hex letter
 	}
 )
 
 /*
-looksLikeActualBase64 uses some regex based heuristics to avoid false positive matching
-of long words, hex strings, file paths, etc. as base64 strings, by checking that the
-candidate string matches the regexes defined above
+looksLikeActualBase64 checks a candidate base64 string (that matches base64Regex)
+using some rule-based heuristics to reduce false positive matching of e.g.
+long words, hex strings, file paths. Additionally, if the candidate string
+uses padding, its length is checked to ensure it is a multiple of 4 as required
+by the Base64 standard.
 */
 func looksLikeActualBase64(candidate string) bool {
+	if strings.ContainsRune(candidate, '=') && len(candidate)%4 != 0 {
+		return false
+	}
+
 	for _, r := range filterRegexes {
 		if !r.MatchString(candidate) {
 			return false
 		}
 	}
+
 	return true
 }
 
 /*
 FindBase64Substrings returns a slice containing all the non-overlapping substrings of s
-that are at least 12 characters long, and look like base64-encoded data. The function
+that are at least 20 characters long, and look like base64-encoded data. The function
 uses regex-based heuristics to determine valid substrings but does not decode the data.
-In particular, valid strings must have only valid base64 characters ([A-Za-z0-9+/]),
-and have correct padding ('=') chars. Additionally, the following heuristics are used:
+In particular, valid strings must have only valid base64 characters ([A-Za-z0-9+/] or
+[A-Za-z0-9-_], depending on the variant, plus up to 2 padding '=' characters).
+If padding characters are included, then the string length must be a multiple of 4.
 
-1. Valid strings contain one letter outside a-f (or A-F). This filters out hex literals.
-2. Valid strings contain one uppercase letter and one lowercase letter
+The following heuristic rules are checked to reduce the number of false positives.
 
-With a moderate sized input string, there will likely be some false positive matches.
-Due to the 12 character minimum length, however, it is highly unlikely that a legitimate
-base64 string will be excluded from the output. Additionally, if there are multiple
-base64 encoded strings in the input, depending on how they are separated, they may
-end up being concatenated together in a single element of the returned string slice.
+1. Must have at least one uppercase letter
+2. Must have at least one lowercase letter
+3. Must have at least one letter outside A-F (or a-f) [this filters out hex strings]
+4. If padding characters are included, the string length must be a multiple of 4
+
+While false positive matches will occur, due to the minimum length requirement
+it is highly unlikely that a legitimate base64 string will be excluded from the output.
+
+Note that, if there are multiple base64 encoded strings in the input, depending
+on how they are separated, they may end up being concatenated together into a single
+string in the returned string slice.
 */
 func FindBase64Substrings(s string) []string {
 	matches := []string{}

--- a/internal/staticanalysis/obfuscation/base64/base64_detect_test.go
+++ b/internal/staticanalysis/obfuscation/base64/base64_detect_test.go
@@ -1,0 +1,42 @@
+package base64
+
+import (
+	"reflect"
+	"testing"
+)
+
+const longBase64String = "IkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0LCBjb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQsIHNlZCBkby" +
+	"BlaXVzbW9kIHRlbXBvciBpbmNpZGlkdW50IHV0IGxhYm9yZSBldCBkb2xvcmUgbWFnbmEgYWxpcXVhLiBVdCBlbmltIGFkIG1pbmltIHZlb" +
+	"mlhbSwgcXVpcyBub3N0cnVkIGV4ZXJjaXRhdGlvbiB1bGxhbWNvIGxhYm9yaXMgbmlzaSB1dCBhbGlxdWlwIGV4IGVhIGNvbW1vZG8gY29u" +
+	"c2VxdWF0LiBEdWlzIGF1dGUgaXJ1cmUgZG9sb3IgaW4gcmVwcmVoZW5kZXJpdCBpbiB2b2x1cHRhdGUgdmVsaXQgZXNzZSBjaWxsdW0gZG9" +
+	"sb3JlIGV1IGZ1Z2lhdCBudWxsYSBwYXJpYXR1ci4gRXhjZXB0ZXVyIHNpbnQgb2NjYWVjYXQgY3VwaWRhdGF0IG5vbiBwcm9pZGVudCwgc3V" +
+	"udCBpbiBjdWxwYSBxdWkgb2ZmaWNpYSBkZXNlcnVudCBtb2xsaXQgYW5pbSBpZCBlc3QgbGFib3J1bS4i"
+
+func TestFindBase64Substrings(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output []string
+	}{
+		{"empty", "", []string{}},
+		{"16 lowercase chars", "abcdefghijklmnop", []string{}},
+		{"16 uppercase chars", "ABCDEFGHIJKLMNOP", []string{}},
+		{"16 digits", "1234123412341234", []string{}},
+		{"16 chars lowercase hex", "0x0123456789abcd", []string{}},
+		{"16 chars uppercase hex", "0XABCDEF12345678", []string{}},
+		{"actual base64 no padding", "dGhpcyBpcyBhbiBvcmFuZ2UK", []string{"dGhpcyBpcyBhbiBvcmFuZ2UK"}},
+		{"actual base64 1 padding", "dGhpcyBpcyBhIHBlYXI=", []string{"dGhpcyBpcyBhIHBlYXI="}},
+		{"actual base64 2 padding", "dGhpcyBpcyBhbiBhcHBsZQ==", []string{"dGhpcyBpcyBhbiBhcHBsZQ=="}},
+		{"actual base64 3 padding", "0XABCDEF12345678", []string{}},
+		{"long base64 string", longBase64String, []string{longBase64String}},
+		{"multiple base64 strings", longBase64String + " " + longBase64String,
+			[]string{longBase64String, longBase64String}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindBase64Substrings(tt.input); !reflect.DeepEqual(got, tt.output) {
+				t.Errorf("FindBase64Substrings() = %v, want %v", got, tt.output)
+			}
+		})
+	}
+}

--- a/internal/staticanalysis/obfuscation/compute_signals.go
+++ b/internal/staticanalysis/obfuscation/compute_signals.go
@@ -83,7 +83,7 @@ func ComputeSignals(rawData FileData) FileSignals {
 		for _, candidate := range matches {
 			// use some extra checks to reduce false positives
 			if digit.MatchString(candidate) && nonHexLetter.MatchString(candidate) {
-				signals.Base64Strings = append(signals.Base64Strings, matches...)
+				signals.Base64Strings = append(signals.Base64Strings, candidate)
 			}
 		}
 	}

--- a/internal/staticanalysis/obfuscation/compute_signals.go
+++ b/internal/staticanalysis/obfuscation/compute_signals.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/base64"
 	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/stats"
 	"github.com/ossf/package-analysis/internal/staticanalysis/obfuscation/stringentropy"
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
@@ -15,15 +16,6 @@ var suspiciousIdentifierPatterns = map[string]*regexp.Regexp{
 	"hex":     regexp.MustCompile("^_0x\\d{3,}$"),
 	"numeric": regexp.MustCompile("^[A-Za-z_]?\\d{3,}$"),
 }
-
-// Adapted from https://stackoverflow.com/a/5885097 to only match
-// base64 strings with at least 12 characters
-var longBase64String = regexp.MustCompile("(?:[A-Za-z0-9+/]{4}){3,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})")
-
-// to avoid false positive matching on long words, hex strings or file paths, etc.
-// check for at least one digit and one letter outside a-f
-var digit = regexp.MustCompile("\\d")
-var nonHexLetter = regexp.MustCompile("[G-Zg-z]")
 
 /*
 characterAnalysis performs analysis on a collection of string symbols, returning:
@@ -79,13 +71,7 @@ func ComputeSignals(rawData FileData) FileSignals {
 
 	signals.Base64Strings = []string{}
 	for _, s := range literals {
-		matches := longBase64String.FindAllString(s, -1)
-		for _, candidate := range matches {
-			// use some extra checks to reduce false positives
-			if digit.MatchString(candidate) && nonHexLetter.MatchString(candidate) {
-				signals.Base64Strings = append(signals.Base64Strings, candidate)
-			}
-		}
+		signals.Base64Strings = append(signals.Base64Strings, base64.FindBase64Substrings(s)...)
 	}
 
 	return signals


### PR DESCRIPTION
1. Fix a bug where a whole list of candidate base64 strings were added to the result data structure instead of just the one being tested
2. Refactor base64 detection logic to its own package
3. Improve the heuristics used to limit false positives - it's easy to make a base64 string with no digits, so this was a poor heuristic; having at least one uppercase and one lowercase character is a much better heuristic
4. Add unit tests for base64 detection
5. Add better comments to functions
6. Make padding optional as not all variants of the standard require it
7. Increase minimum length of base64 strings to 16 as shorter strings are not as useful for obfuscation detection