### PR TITLE
Save write buffer in separate files and create file identifiers

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -103,6 +103,12 @@ func dynamicAnalysis(pkg *pkgecosystem.Pkg) {
 		if err != nil {
 			log.Fatal("Failed to upload file write analysis results to blobstore", "error", err)
 		}
+		for _, writeBuf := range results.FileWriteBuffers {
+			writeBuffErr := resultstore.New(bucket, resultstore.BasePath(path)).SaveWriteBuffer(ctx, pkg, writeBuf, utils.GetSHA256Hash(writeBuf))
+			if writeBuffErr != nil {
+				log.Fatal(" Failed to upload file write buffer results to blobstore", "error")
+			}
+		}
 	}
 
 	// this is only valid if RunDynamicAnalysis() returns nil err

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -103,9 +103,9 @@ func dynamicAnalysis(pkg *pkgecosystem.Pkg) {
 		if err != nil {
 			log.Fatal("Failed to upload file write analysis results to blobstore", "error", err)
 		}
-		for _, writeBuf := range results.FileWriteBuffers {
-			writeBuffErr := resultstore.New(bucket, resultstore.BasePath(path)).SaveWriteBuffer(ctx, pkg, writeBuf, utils.GetSHA256Hash(writeBuf))
-			if writeBuffErr != nil {
+		for _, writeBuffer := range results.FileWriteBuffers {
+			writeBufferErr := resultstore.New(bucket, resultstore.BasePath(path)).SaveWriteBuffer(ctx, pkg, writeBuffer, utils.GetSHA256Hash(writeBuffer))
+			if writeBufferErr != nil {
 				log.Fatal(" Failed to upload file write buffer results to blobstore", "error")
 			}
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -130,9 +130,9 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		if err != nil {
 			return fmt.Errorf("failed to upload file write analysis to blobstore = %w", err)
 		}
-		for _, writeBuf := range results.FileWriteBuffers {
-			writeBuffErr := resultstore.New(fileWritesBucket, resultstore.ConstructPath()).SaveWriteBuffer(ctx, pkg, writeBuf, utils.GetSHA256Hash(writeBuf))
-			if writeBuffErr != nil {
+		for _, writeBuffer := range results.FileWriteBuffers {
+			writeBufferErr := resultstore.New(fileWritesBucket, resultstore.ConstructPath()).SaveWriteBuffer(ctx, pkg, writeBuffer, utils.GetSHA256Hash(writeBuffer))
+			if writeBufferErr != nil {
 				log.Fatal(" Failed to upload file write buffer results to blobstore", "error")
 			}
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/ossf/package-analysis/internal/utils"
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/gcsblob"
@@ -128,6 +129,12 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		err := resultstore.New(fileWritesBucket, resultstore.ConstructPath()).Save(ctx, pkg, results.FileWrites)
 		if err != nil {
 			return fmt.Errorf("failed to upload file write analysis to blobstore = %w", err)
+		}
+		for _, writeBuf := range results.FileWriteBuffers {
+			writeBuffErr := resultstore.New(fileWritesBucket, resultstore.ConstructPath()).SaveWriteBuffer(ctx, pkg, writeBuf, utils.GetSHA256Hash(writeBuf))
+			if writeBuffErr != nil {
+				log.Fatal(" Failed to upload file write buffer results to blobstore", "error")
+			}
 		}
 	}
 

--- a/internal/dynamicanalysis/analysis.go
+++ b/internal/dynamicanalysis/analysis.go
@@ -18,8 +18,9 @@ const (
 )
 
 type Result struct {
-	StraceSummary result.StraceSummary
-	FileWrites    result.FileWrites
+	StraceSummary    result.StraceSummary
+	FileWrites       result.FileWrites
+	FileWriteBuffers []string
 }
 
 var resultError = &Result{
@@ -86,7 +87,10 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 			Delete: f.Delete,
 		})
 		if len(f.WriteInfo) > 0 {
-			d.FileWrites = append(d.FileWrites, result.FileWriteResult{f.Path, f.WriteInfo})
+			d.FileWrites = append(d.FileWrites, result.FileWriteResult{Path: f.Path, WriteInfo: f.WriteInfo})
+			for _, writeBuf := range f.WriteBuffers {
+				d.FileWriteBuffers = append(d.FileWriteBuffers, writeBuf)
+			}
 		}
 	}
 

--- a/internal/dynamicanalysis/analysis.go
+++ b/internal/dynamicanalysis/analysis.go
@@ -88,8 +88,8 @@ func (d *Result) setData(straceResult *strace.Result, dns *dnsanalyzer.DNSAnalyz
 		})
 		if len(f.WriteInfo) > 0 {
 			d.FileWrites = append(d.FileWrites, result.FileWriteResult{Path: f.Path, WriteInfo: f.WriteInfo})
-			for _, writeBuf := range f.WriteBuffers {
-				d.FileWriteBuffers = append(d.FileWriteBuffers, writeBuf)
+			for _, writeBuffer := range f.WriteBuffers {
+				d.FileWriteBuffers = append(d.FileWriteBuffers, writeBuffer)
 			}
 		}
 	}

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -55,12 +55,7 @@ func (rs *ResultStore) generatePath(p Pkg) string {
 	return path
 }
 
-func (rs *ResultStore) OpenAndWriteToBucket(ctx context.Context, result any, path, filename string) error {
-	b, err := json.Marshal(result)
-	if err != nil {
-		return err
-	}
-
+func (rs *ResultStore) OpenAndWriteToBucket(ctx context.Context, contents []byte, path, filename string) error {
 	bkt, err := blob.OpenBucket(ctx, rs.bucket)
 	if err != nil {
 		return err
@@ -76,7 +71,7 @@ func (rs *ResultStore) OpenAndWriteToBucket(ctx context.Context, result any, pat
 	if err != nil {
 		return err
 	}
-	if _, err := w.Write(b); err != nil {
+	if _, err := w.Write(contents); err != nil {
 		return err
 	}
 	if err := w.Close(); err != nil {
@@ -88,7 +83,7 @@ func (rs *ResultStore) OpenAndWriteToBucket(ctx context.Context, result any, pat
 
 func (rs *ResultStore) SaveWriteBuffer(ctx context.Context, p Pkg, writeBuffer, fileName string) error {
 	path := filepath.Join(rs.generatePath(p), writeBufferFolder)
-	return rs.OpenAndWriteToBucket(ctx, writeBuffer, path, fileName+".json")
+	return rs.OpenAndWriteToBucket(ctx, []byte(writeBuffer), path, fileName+".json")
 }
 
 func (rs *ResultStore) Save(ctx context.Context, p Pkg, analysis interface{}) error {
@@ -107,5 +102,11 @@ func (rs *ResultStore) Save(ctx context.Context, p Pkg, analysis interface{}) er
 	if version != "" {
 		filename = version + ".json"
 	}
-	return rs.OpenAndWriteToBucket(ctx, result, rs.generatePath(p), filename)
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	return rs.OpenAndWriteToBucket(ctx, b, rs.generatePath(p), filename)
 }

--- a/internal/strace/strace.go
+++ b/internal/strace/strace.go
@@ -192,11 +192,16 @@ func (r *Result) parseEnterSyscall(syscall, args string) error {
 		}
 		writeBuffer := ""
 		match := writePattern.FindStringSubmatch(args)
-		// Get the first index of the quotes and last index of the quotes. If they don't exist then just put "" otherwise take the values in between.
-		if bytesWritten > 0 {
-			firstQuoteIndex := strings.Index(args, "\"")
-			lastQuoteIndex := strings.LastIndex(args, "\"")
+		firstQuoteIndex := strings.Index(args, "\"")
+		lastQuoteIndex := strings.LastIndex(args, "\"")
+		if firstQuoteIndex != -1 && lastQuoteIndex != -1 && lastQuoteIndex > firstQuoteIndex {
+			// Save the contents between the first and last quote.
 			writeBuffer = args[firstQuoteIndex+1 : lastQuoteIndex]
+			lastIndexComma := strings.LastIndex(args, ",")
+			if lastQuoteIndex+1 != lastIndexComma {
+				// If the write buffer is truncated there will be an ellipses after the quoted write buffer. Save this as well.
+				writeBuffer += args[lastQuoteIndex+1 : lastIndexComma]
+			}
 		}
 		r.recordFileWrite(match[1], writeBuffer, bytesWritten)
 	}

--- a/internal/strace/strace_test.go
+++ b/internal/strace/strace_test.go
@@ -50,10 +50,12 @@ func TestParseFileWriteMultipleWritesToSameFile(t *testing.T) {
 	input := "I0928 00:18:54.794008     365 strace.go:593] [   6:   6] uname E write(0x1 host:[5], 0x555695ceaab0 \"Linux 4.4.0\\n\", 0xc)\n" +
 		"I1109 06:53:19.688807     950 strace.go:593] [   3:   3] python3 E write(0x1 host:[5], 0x560d2708e7c0 \"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport\"..., 0xe64)"
 	firstFileInfoWant := strace.WriteContentInfo{
-		BytesWritten: 12,
+		BytesWritten:  12,
+		WriteBufferId: "181080a0b2dce592f16ab55aacb18c7a4cb849c9a7f644c5c76edf56e4870ebd",
 	}
 	secondFileInfoWant := strace.WriteContentInfo{
-		BytesWritten: 3684,
+		BytesWritten:  3684,
+		WriteBufferId: "7b2c403bc9eee677758c2a575b2f8602b37f880f4fdb98ee98c30a74a5b9a52b",
 	}
 	fileInfoWantArray := strace.WriteInfo{firstFileInfoWant, secondFileInfoWant}
 
@@ -82,7 +84,8 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 		Write: true,
 		WriteInfo: strace.WriteInfo{
 			{
-				BytesWritten: 12,
+				BytesWritten:  12,
+				WriteBufferId: "181080a0b2dce592f16ab55aacb18c7a4cb849c9a7f644c5c76edf56e4870ebd",
 			},
 		},
 	}
@@ -92,7 +95,8 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 		Write: true,
 		WriteInfo: strace.WriteInfo{
 			{
-				BytesWritten: 3684,
+				BytesWritten:  3684,
+				WriteBufferId: "7b2c403bc9eee677758c2a575b2f8602b37f880f4fdb98ee98c30a74a5b9a52b",
 			},
 		},
 	}
@@ -119,6 +123,8 @@ func TestParseFileWriteWithZeroBytesWritten(t *testing.T) {
 		WriteInfo: strace.WriteInfo{
 			{
 				BytesWritten: 0,
+				// sha256 of empty string.
+				WriteBufferId: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
 		},
 	}

--- a/internal/strace/strace_test.go
+++ b/internal/strace/strace_test.go
@@ -80,7 +80,6 @@ func TestParseFileWriteMultipleWritesToSameFile(t *testing.T) {
 func TestParseFileWritesToDifferentFiles(t *testing.T) {
 	input := "I0928 00:18:54.794008     365 strace.go:593] [   6:   6] uname E write(0x1 host:[5], 0x555695ceaab0 \"Linux 4.4.0\\n\", 0xc)\n" +
 		"I1109 06:53:19.688807     950 strace.go:593] [   3:   3] python3 E write(0x1 pipe:[5], 0x560d2708e7c0 \"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport\"..., 0xe64)"
-	log.Debug(input)
 	firstFileInfo := strace.FileInfo{
 		Path:  "host:[5]",
 		Write: true,
@@ -112,8 +111,8 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 		t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
 	}
 	files := res.Files()
-	if !reflect.DeepEqual(files[0], want) {
-		t.Errorf(`Files() = %v, want  = %v`, files[0], want)
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf(`Files() = %v, want  = %v`, files, want)
 	}
 }
 

--- a/internal/strace/strace_test.go
+++ b/internal/strace/strace_test.go
@@ -55,14 +55,15 @@ func TestParseFileWriteMultipleWritesToSameFile(t *testing.T) {
 	}
 	secondFileInfoWant := strace.WriteContentInfo{
 		BytesWritten:  3684,
-		WriteBufferId: "7b2c403bc9eee677758c2a575b2f8602b37f880f4fdb98ee98c30a74a5b9a52b",
+		WriteBufferId: "7719f4b5f43eda5bf95d9cc31134c86711b5cbaa689441b570a487bf4b9c5e61",
 	}
 	fileInfoWantArray := strace.WriteInfo{firstFileInfoWant, secondFileInfoWant}
 
 	want := strace.FileInfo{
-		Path:      "host:[5]",
-		Write:     true,
-		WriteInfo: fileInfoWantArray,
+		Path:         "host:[5]",
+		Write:        true,
+		WriteInfo:    fileInfoWantArray,
+		WriteBuffers: []string{"Linux 4.4.0\\n", "django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport..."},
 	}
 
 	r := strings.NewReader(input)
@@ -79,6 +80,7 @@ func TestParseFileWriteMultipleWritesToSameFile(t *testing.T) {
 func TestParseFileWritesToDifferentFiles(t *testing.T) {
 	input := "I0928 00:18:54.794008     365 strace.go:593] [   6:   6] uname E write(0x1 host:[5], 0x555695ceaab0 \"Linux 4.4.0\\n\", 0xc)\n" +
 		"I1109 06:53:19.688807     950 strace.go:593] [   3:   3] python3 E write(0x1 pipe:[5], 0x560d2708e7c0 \"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport\"..., 0xe64)"
+	log.Debug(input)
 	firstFileInfo := strace.FileInfo{
 		Path:  "host:[5]",
 		Write: true,
@@ -88,6 +90,7 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 				WriteBufferId: "181080a0b2dce592f16ab55aacb18c7a4cb849c9a7f644c5c76edf56e4870ebd",
 			},
 		},
+		WriteBuffers: []string{"Linux 4.4.0\\n"},
 	}
 
 	secondFileInfo := strace.FileInfo{
@@ -96,9 +99,10 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 		WriteInfo: strace.WriteInfo{
 			{
 				BytesWritten:  3684,
-				WriteBufferId: "7b2c403bc9eee677758c2a575b2f8602b37f880f4fdb98ee98c30a74a5b9a52b",
+				WriteBufferId: "7719f4b5f43eda5bf95d9cc31134c86711b5cbaa689441b570a487bf4b9c5e61",
 			},
 		},
+		WriteBuffers: []string{"django.template.base\\nImporting django.template.context\\nImporting django.template.context_processors\\nImporting django.template.defaultfilters\\nImporting django.template.defaulttags\\nImporting django.template.engine\\nImporting django.template.exceptions\\nImporting django.template.library\\nImporting django.template.loader\\nImporting django.template.loader_tags\\nImporting django.template.loaders\\nImporting django.template.loaders.app_directories\\nImporting django.template.loaders.base\\nImporting django.template.loaders.cached\\nImporting django.template.loaders.filesystem\\nImporting django.template.loaders.locmem\\nImporting django.template.response\\nImporting django.template.smartif\\nImporting django.template.utils\\nImporting django.templatetags\\nImporting django.templatetags.cache\\nImporting django.templatetags.i18n\\nImporting django.templatetags.l10n\\nImporting django.templatetags.static\\nImporting django.templatetags.tz\\nImporting django.test\\nImporting django.test.client\\nImporting django.test.html\\nImporting django.test.runner\\nImport..."},
 	}
 	want := []strace.FileInfo{firstFileInfo, secondFileInfo}
 
@@ -108,8 +112,8 @@ func TestParseFileWritesToDifferentFiles(t *testing.T) {
 		t.Errorf(`Parse(r) = %v, %v, want _, nil`, res, err)
 	}
 	files := res.Files()
-	if !reflect.DeepEqual(files, want) {
-		t.Errorf(`Files() = %v, want  = %v`, files, want)
+	if !reflect.DeepEqual(files[0], want) {
+		t.Errorf(`Files() = %v, want  = %v`, files[0], want)
 	}
 }
 
@@ -127,6 +131,7 @@ func TestParseFileWriteWithZeroBytesWritten(t *testing.T) {
 				WriteBufferId: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
 		},
+		WriteBuffers: []string{""},
 	}
 
 	r := strings.NewReader(input)

--- a/internal/utils/sha256_hash.go
+++ b/internal/utils/sha256_hash.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func GetSHA256Hash(content string) string {
+	hash := sha256.New()
+	hash.Write([]byte(content))
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/internal/utils/sha256_hash_test.go
+++ b/internal/utils/sha256_hash_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"testing"
+)
+
+// Test multiple hash queries to make sure the hashes are computed as expected.
+func TestMultipleHashQueries(t *testing.T) {
+	firstTestString := "First test string"
+	secondTestString := "Second test string"
+	firstExpectedHash := "bdb0b089f806e5fc8e71198c965d351c5ff28ff6ea6e5d8fff31bf55c7267b25"
+	secondExpectedHash := "51fa0cdbe10324f18ac4d123eb29a402be2f3b9c5623a12ea013ec7e5fbb655e"
+	firstHash := GetSHA256Hash(firstTestString)
+	if firstHash != firstExpectedHash {
+		t.Errorf(`Expected = %v, Actual  = %v`, firstExpectedHash, firstHash)
+	}
+	secondHash := GetSHA256Hash(secondTestString)
+	if secondHash != secondExpectedHash {
+		t.Errorf(`Expected = %v, Actual  = %v`, secondExpectedHash, secondHash)
+	}
+}

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -63,6 +63,7 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 
 		results.StraceSummary[phase] = &result.StraceSummary
 		results.FileWrites[phase] = &result.FileWrites
+		results.FileWriteBuffers = append(results.FileWriteBuffers, result.FileWriteBuffers...)
 		lastStatus = result.StraceSummary.Status
 
 		if lastStatus != analysis.StatusCompleted {
@@ -77,6 +78,5 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 	} else {
 		LogDynamicAnalysisResult(pkg, lastRunPhase, lastStatus)
 	}
-
 	return results, lastRunPhase, lastStatus, lastError
 }

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -10,8 +10,9 @@ type DynamicAnalysisStraceSummary map[pkgecosystem.RunPhase]*StraceSummary
 type DynamicAnalysisFileWrites map[pkgecosystem.RunPhase]*FileWrites
 
 type DynamicAnalysisResults struct {
-	StraceSummary DynamicAnalysisStraceSummary
-	FileWrites    DynamicAnalysisFileWrites
+	StraceSummary    DynamicAnalysisStraceSummary
+	FileWrites       DynamicAnalysisFileWrites
+	FileWriteBuffers []string
 }
 
 type StraceSummary struct {


### PR DESCRIPTION
This PR saves each write buffer in individual files. We use the hash of the write buffer contents as a file identifier and establish a mapping between the write results summary stored in the main .json file and the write buffer file each write syscall corresponds to. 