### PR TITLE
add file hashes and output of file command to static analysis data

### DIFF
--- a/internal/staticanalysis/obfuscation/data.go
+++ b/internal/staticanalysis/obfuscation/data.go
@@ -104,7 +104,7 @@ type AnalysisResult struct {
 	// FileHashes maps file names to SHA256 hashes of the files.
 	FileHashes map[string]string
 
-	// FileHashes maps file names to the output of the `file`
+	// FileTypes maps file names to the output of the `file`
 	// command run on that file
 	FileTypes map[string]string
 }

--- a/internal/staticanalysis/obfuscation/data.go
+++ b/internal/staticanalysis/obfuscation/data.go
@@ -95,10 +95,18 @@ type AnalysisResult struct {
 	// parsers encountered syntax errors when analysing the file.
 	ExcludedFiles []string
 
-	// FileSizes is a map from file name to size in bytes, and
-	// is populated with data from all files in the package,
-	// regardless of whether they were included in the analysis.
+	// The maps below contain data on all files in the package,
+	// regardless of whether they were included in analysis.
+
+	// FileSizes maps file names to file sizes in bytes.
 	FileSizes map[string]int64
+
+	// FileHashes maps file names to SHA256 hashes of the files.
+	FileHashes map[string]string
+
+	// FileHashes maps file names to the output of the `file`
+	// command run on that file
+	FileTypes map[string]string
 }
 
 func (rd FileData) String() string {

--- a/internal/utils/hash_file.go
+++ b/internal/utils/hash_file.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+)
+
+func HashFile(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(bytes)
+	return fmt.Sprintf("sha256:%x", hash), nil
+}

--- a/sandboxes/staticanalysis/Dockerfile
+++ b/sandboxes/staticanalysis/Dockerfile
@@ -9,7 +9,8 @@ RUN go mod download
 RUN CGO_ENABLED=0 go build -o staticanalyze staticanalyze.go
 
 FROM alpine:3.17.1@sha256:93d5a28ff72d288d69b5997b8ba47396d2cbb62a72b5d87cd3351094b5d578a0
-RUN apk add --no-cache nodejs && \
+RUN apk add --no-cache file && \
+	apk add --no-cache nodejs && \
 	apk add --no-cache npm && \
 	apk add --no-cache python3
 


### PR DESCRIPTION
Adds SHA256 hashes of each package file, as well as the output of the `file` command run on each package file, to the static analysis output 

Fixes #576 

Signed-off-by: Max Fisher <maxfisher@google.com>