### PR TITLE
use `env python3` instead of `python3` in script

### DIFF
--- a/batch-analysis/format-json.py
+++ b/batch-analysis/format-json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 Custom tool to pretty-print JSON with certain fields compacted


### PR DESCRIPTION
Signed-off-by: Max Fisher <maxfisher@google.com>