### PR TITLE
Enable worker to run static analysis when environment variable is set

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -59,7 +59,6 @@ func copyPackageToLocalFile(ctx context.Context, packagesBucket *blob.Bucket, bu
 	if err != nil {
 		return "", nil, err
 	}
-	defer os.Remove(f.Name())
 
 	if _, err := io.Copy(f, r); err != nil {
 		return "", nil, err
@@ -139,6 +138,9 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		if err != nil {
 			return err
 		}
+
+		defer os.Remove(pkgFile.Name())
+
 		localPkgPath = tmpPkgPath
 		mountOption := sandbox.Volume(pkgFile.Name(), localPkgPath)
 		// mount temp file into the sandboxes

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -160,9 +160,12 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 		return err
 	}
 
-	staticResults, _, err := worker.RunStaticAnalyses(pkg, staticSandboxOpts)
-	if err != nil {
-		return err
+	var staticResults result.StaticAnalysisResults
+	if resultsBuckets.staticAnalysis != "" {
+		staticResults, _, err = worker.RunStaticAnalyses(pkg, staticSandboxOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = saveResults(ctx, pkg, resultsBuckets, results, staticResults)

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -12,13 +11,20 @@ import (
 	"github.com/ossf/package-analysis/internal/sandbox"
 	"github.com/ossf/package-analysis/internal/staticanalysis"
 	"github.com/ossf/package-analysis/internal/utils"
+	"github.com/ossf/package-analysis/pkg/result"
 )
 
 const staticAnalysisImage = "gcr.io/ossf-malware-analysis/static-analysis"
 const staticAnalyzeBinary = "/usr/local/bin/staticanalyze"
 const resultsJSONFile = "/results.json"
 
-func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (json.RawMessage, analysis.Status, error) {
+/*
+RunStaticAnalyses performs sandboxed static analysis on the given package.
+Use sbOpts to customise sandbox behaviour.
+If len(tasks) > 0, only the specified static analysis tasks will be performed.
+Otherwise, all available tasks [staticanalysis.AllTasks()] will be performed.
+*/
+func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (result.StaticAnalysisResults, analysis.Status, error) {
 	if len(tasks) == 0 {
 		tasks = staticanalysis.AllTasks()
 	}
@@ -69,5 +75,9 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 
 	log.Info("Got results", "length", len(resultsJSON))
 
-	return resultsJSON, analysis.StatusForRunResult(runResult), nil
+	status := analysis.StatusForRunResult(runResult)
+
+	// TODO log status
+
+	return resultsJSON, status, nil
 }

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"encoding/json"
+
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/pkgecosystem"
 	"github.com/ossf/package-analysis/internal/strace"
@@ -13,6 +15,8 @@ type DynamicAnalysisResults struct {
 	StraceSummary DynamicAnalysisStraceSummary
 	FileWrites    DynamicAnalysisFileWrites
 }
+
+type StaticAnalysisResults = json.RawMessage
 
 type StraceSummary struct {
 	Status   analysis.Status


### PR DESCRIPTION
This PR adds functionality to the worker so that when a bucket path is configured in the environment variables, it will run static analysis on packages and upload the results to that bucket.

The environment variable config change will be added in another PR.  

Some refactoring was also done to worker.go:

- Extract logic into a new function for copying from a specified remote package bucket to a temp file
- Replace deprecated `ioutil.TempFile()` with `os.CreateTemp()`
- Extract logic into a new function for saving all the analysis results to their respective buckets

Finally, a new type `result.StaticAnalysisResults` was added to `pkg/results` to parallel `result.DynamicAnalysisResults`.

Signed-off-by: Max Fisher <maxfisher@google.com>