### PR TITLE
Add static analysis bucket config to worker config and docker-compose example

### DIFF
--- a/examples/e2e/docker-compose.yml
+++ b/examples/e2e/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       MINIO_ROOT_PASSWORD: minio123
       MINIO_REGION_NAME: dummy_region
     entrypoint: sh
-    command: -c 'mkdir -p /data/{package-analysis,package-analysis-file-writes} && /usr/bin/minio server /data'
+    command: -c 'mkdir -p /data/package-analysis{,-static,-file-writes} && /usr/bin/minio server /data'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
@@ -48,6 +48,7 @@ services:
       OSSMALWARE_WORKER_SUBSCRIPTION: kafka://worker?topic=workers
       OSSF_MALWARE_NOTIFICATION_TOPIC: kafka://notifications
       OSSF_MALWARE_ANALYSIS_RESULTS: s3://package-analysis?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
+      OSSF_MALWARE_STATIC_ANALYSIS_RESULTS: s3://package-analysis-static?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS: s3://package-analysis-file-writes?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       KAFKA_BROKERS: kafka:9092
       AWS_ACCESS_KEY_ID: minio
@@ -65,7 +66,7 @@ services:
       OSSMALWARE_WORKER_TOPIC: kafka://workers
       OSSMALWARE_SUBSCRIPTION_URL: kafka://worker?topic=package-feeds
       KAFKA_BROKERS: kafka:9092
-  
+
   feeds:
     restart: "on-failure"
     image: gcr.io/ossf-malware-analysis/scheduled-feeds:latest

--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -25,6 +25,8 @@ spec:
           value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results
+        - name: OSSF_MALWARE_STATIC_ANALYSIS_RESULTS
+          value: gs://ossf-malware-static-analysis-results
         - name: OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS
           value: gs://ossf-malware-analysis-file-write-results
         - name: LOGGER_ENV
@@ -54,4 +56,4 @@ spec:
       storageClassName: premium-rwo
       resources:
         requests:
-          storage: 30Gi  
+          storage: 30Gi


### PR DESCRIPTION
This change will enable static analysis in production when deployed

Signed-off-by: Max Fisher <maxfisher@google.com>