### PR TITLE
Don't enable static analysis in production (yet)

### DIFF
--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -25,8 +25,8 @@ spec:
           value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results
-        - name: OSSF_MALWARE_STATIC_ANALYSIS_RESULTS
-          value: gs://ossf-malware-static-analysis-results
+#       - name: OSSF_MALWARE_STATIC_ANALYSIS_RESULTS
+#         value: gs://ossf-malware-static-analysis-results
         - name: OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS
           value: gs://ossf-malware-analysis-file-write-results
         - name: LOGGER_ENV


### PR DESCRIPTION
Temporary reversion of the config change to enable static analysis, awaiting completion of #605 first

Signed-off-by: Max Fisher <maxfisher@google.com>