### PR TITLE
log execution times for analyses and remove log.Label usages in staticanalyze.go

### DIFF
--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -59,10 +59,10 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 
 		runDuration := time.Since(startTime)
 		log.Info("Dynamic analysis phase finished",
-			"ecosystem", pkg.EcosystemName(),
+			log.Label("ecosystem", pkg.EcosystemName()),
 			"name", pkg.Name(),
 			"version", pkg.Version(),
-			"phase", string(phase),
+			log.Label("phase", string(phase)),
 			"error", err,
 			"dynamic_analysis_phase_duration_sec", fmt.Sprintf("%.1f", runDuration.Seconds()),
 		)

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/ossf/package-analysis/internal/analysis"
@@ -60,12 +59,12 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 
 		runDuration := time.Since(startTime)
 		log.Info("Dynamic analysis phase finished",
-			log.Label("ecosystem", pkg.EcosystemName()),
-			log.Label("name", pkg.Name()),
-			log.Label("version", pkg.Version()),
-			log.Label("phase", string(phase)),
-			log.Label("error", strconv.FormatBool(err != nil)),
-			log.Label("dynamic_analysis_phase_duration_sec", fmt.Sprintf("%.1f", runDuration.Seconds())),
+			"ecosystem", pkg.EcosystemName(),
+			"name", pkg.Name(),
+			"version", pkg.Version(),
+			"phase", string(phase),
+			"error", err,
+			"dynamic_analysis_phase_duration_sec", fmt.Sprintf("%.1f", runDuration.Seconds()),
 		)
 
 		if err != nil {

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -1,6 +1,9 @@
 package worker
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/dynamicanalysis"
 	"github.com/ossf/package-analysis/internal/log"
@@ -50,20 +53,27 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 	var lastStatus analysis.Status
 	var lastError error
 	for _, phase := range pkg.Manager().RunPhases() {
-		result, err := dynamicanalysis.Run(sb, pkg.Command(phase))
+		startTime := time.Now()
+		phaseResult, err := dynamicanalysis.Run(sb, pkg.Command(phase))
 		lastRunPhase = phase
+
+		runDuration := time.Since(startTime)
+		durationString := fmt.Sprintf("%.1fs", runDuration.Seconds())
 
 		if err != nil {
 			// Error when trying to actually run; don't record the result for this phase
 			// or attempt subsequent phases
 			lastStatus = ""
 			lastError = err
+			log.Warn("Analysis failed after "+durationString, "phase", phase)
 			break
 		}
 
-		results.StraceSummary[phase] = &result.StraceSummary
-		results.FileWrites[phase] = &result.FileWrites
-		lastStatus = result.StraceSummary.Status
+		log.Info("Analysis finished in "+durationString, "phase", phase)
+
+		results.StraceSummary[phase] = &phaseResult.StraceSummary
+		results.FileWrites[phase] = &phaseResult.FileWrites
+		lastStatus = phaseResult.StraceSummary.Status
 
 		if lastStatus != analysis.StatusCompleted {
 			// Error caused by an issue with the package (probably).

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ossf/package-analysis/internal/analysis"
@@ -64,7 +63,7 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 			"version", pkg.Version(),
 			log.Label("phase", string(phase)),
 			"error", err,
-			"dynamic_analysis_phase_duration_sec", fmt.Sprintf("%.1f", runDuration.Seconds()),
+			"dynamic_analysis_phase_duration", runDuration,
 		)
 
 		if err != nil {

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/ossf/package-analysis/internal/analysis"
@@ -58,18 +59,22 @@ func RunDynamicAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option) (result.
 		lastRunPhase = phase
 
 		runDuration := time.Since(startTime)
-		durationString := fmt.Sprintf("%.1fs", runDuration.Seconds())
+		log.Info("Dynamic analysis phase finished",
+			log.Label("ecosystem", pkg.EcosystemName()),
+			log.Label("name", pkg.Name()),
+			log.Label("version", pkg.Version()),
+			log.Label("phase", string(phase)),
+			log.Label("error", strconv.FormatBool(err != nil)),
+			log.Label("dynamic_analysis_phase_duration_sec", fmt.Sprintf("%.1f", runDuration.Seconds())),
+		)
 
 		if err != nil {
 			// Error when trying to actually run; don't record the result for this phase
 			// or attempt subsequent phases
 			lastStatus = ""
 			lastError = err
-			log.Warn("Analysis failed after "+durationString, "phase", phase)
 			break
 		}
-
-		log.Info("Analysis finished in "+durationString, "phase", phase)
 
 		results.StraceSummary[phase] = &phaseResult.StraceSummary
 		results.FileWrites[phase] = &phaseResult.FileWrites

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -82,10 +82,10 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 
 	totalTime := time.Since(startTime)
 	log.Info("Static analysis finished",
-		"ecosystem", pkg.EcosystemName(),
+		log.Label("ecosystem", pkg.EcosystemName()),
 		"name", pkg.Name(),
 		"version", pkg.Version(),
-		"status", string(status),
+		"result_status", string(status),
 		"static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds()),
 	)
 

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -85,7 +85,7 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 		log.Label("ecosystem", pkg.EcosystemName()),
 		"name", pkg.Name(),
 		"version", pkg.Version(),
-		"result_status", string(status),
+		log.Label("result_status", string(status)),
 		"static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds()),
 	)
 

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -82,11 +82,11 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 
 	totalTime := time.Since(startTime)
 	log.Info("Static analysis finished",
-		log.Label("ecosystem", pkg.EcosystemName()),
-		log.Label("name", pkg.Name()),
-		log.Label("version", pkg.Version()),
-		log.Label("status", string(status)),
-		log.Label("static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds())),
+		"ecosystem", pkg.EcosystemName(),
+		"name", pkg.Name(),
+		"version", pkg.Version(),
+		"status", string(status),
+		"static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds()),
 	)
 
 	return resultsJSON, status, nil

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/log"
@@ -30,6 +31,8 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 	}
 
 	log.Info("Running static analysis tasks", "tasks", tasks)
+
+	startTime := time.Now()
 
 	analyses := utils.Transform(tasks, func(t staticanalysis.Task) string { return string(t) })
 
@@ -77,7 +80,8 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 
 	status := analysis.StatusForRunResult(runResult)
 
-	// TODO log status
+	totalTime := time.Since(startTime)
+	log.Info(fmt.Sprintf("Analysis finished in %.1f seconds", totalTime.Seconds()), "status", status)
 
 	return resultsJSON, status, nil
 }

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -86,7 +86,7 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 		"name", pkg.Name(),
 		"version", pkg.Version(),
 		log.Label("result_status", string(status)),
-		"static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds()),
+		"static_analysis_duration", totalTime,
 	)
 
 	return resultsJSON, status, nil

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -81,7 +81,13 @@ func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...
 	status := analysis.StatusForRunResult(runResult)
 
 	totalTime := time.Since(startTime)
-	log.Info(fmt.Sprintf("Analysis finished in %.1f seconds", totalTime.Seconds()), "status", status)
+	log.Info("Static analysis finished",
+		log.Label("ecosystem", pkg.EcosystemName()),
+		log.Label("name", pkg.Name()),
+		log.Label("version", pkg.Version()),
+		log.Label("status", string(status)),
+		log.Label("static_analysis_duration_sec", fmt.Sprintf("%.1f", totalTime.Seconds())),
+	)
 
 	return resultsJSON, status, nil
 }

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -202,12 +202,12 @@ func run() (err error) {
 	}
 
 	log.Info("Static analysis launched",
-		"ecosystem", *ecosystem,
+		log.Label("ecosystem", *ecosystem),
 		"package", *packageName,
 		"version", *version,
 		"local_path", *localFile,
 		"output_file", *output,
-		"analyses", strings.Join(uniqueAnalyses, ","))
+		"analyses", uniqueAnalyses)
 
 	workDirs, err := makeWorkDirs()
 	if err != nil {

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -280,7 +280,7 @@ func run() (err error) {
 	otherTime := totalTime - writingResultsTime - analysisTime - extractionTime
 
 	log.Info("Execution times (s)",
-		"extraction", extractionTime,
+		"download and extraction", extractionTime,
 		"analysis", analysisTime,
 		"writing results", writingResultsTime,
 		"other", otherTime,

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -279,7 +279,7 @@ func run() (err error) {
 	totalTime := time.Since(startTime)
 	otherTime := totalTime - writingResultsTime - analysisTime - extractionTime
 
-	log.Info("Execution times (s)",
+	log.Info("Execution times",
 		"download and extraction", extractionTime,
 		"analysis", analysisTime,
 		"writing results", writingResultsTime,

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -280,11 +280,11 @@ func run() (err error) {
 	otherTime := totalTime - writingResultsTime - analysisTime - extractionTime
 
 	log.Info("Execution times (s)",
-		"extraction", extractionTime.String(),
-		"analysis", analysisTime.String(),
-		"writing results", writingResultsTime.String(),
-		"other", otherTime.String(),
-		"total", totalTime.String())
+		"extraction", extractionTime,
+		"analysis", analysisTime,
+		"writing results", writingResultsTime,
+		"other", otherTime,
+		"total", totalTime)
 
 	return nil
 }

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -202,12 +202,12 @@ func run() (err error) {
 	}
 
 	log.Info("Static analysis launched",
-		log.Label("ecosystem", *ecosystem),
-		log.Label("package", *packageName),
-		log.Label("version", *version),
-		log.Label("local_path", *localFile),
-		log.Label("output_file", *output),
-		log.Label("analyses", strings.Join(uniqueAnalyses, ",")))
+		"ecosystem", *ecosystem,
+		"package", *packageName,
+		"version", *version,
+		"local_path", *localFile,
+		"output_file", *output,
+		"analyses", strings.Join(uniqueAnalyses, ","))
 
 	workDirs, err := makeWorkDirs()
 	if err != nil {
@@ -280,11 +280,11 @@ func run() (err error) {
 	otherTime := totalTime - writingResultsTime - analysisTime - extractionTime
 
 	log.Info("Execution times (s)",
-		log.Label("extraction", extractionTime.String()),
-		log.Label("analysis", analysisTime.String()),
-		log.Label("writing results", writingResultsTime.String()),
-		log.Label("other", otherTime.String()),
-		log.Label("total", totalTime.String()))
+		"extraction", extractionTime.String(),
+		"analysis", analysisTime.String(),
+		"writing results", writingResultsTime.String(),
+		"other", otherTime.String(),
+		"total", totalTime.String())
 
 	return nil
 }


### PR DESCRIPTION
Prints execution times for dynamic and static analysis to logs

Fixes #605 

Signed-off-by: Max Fisher <maxfisher@google.com>