### PR TITLE
Refactor static analysis test files 

### DIFF
--- a/internal/staticanalysis/obfuscation/collect_data_test.go
+++ b/internal/staticanalysis/obfuscation/collect_data_test.go
@@ -9,32 +9,32 @@ import (
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
 
-type testCase struct {
+type collectDataTestCase struct {
 	name         string
 	jsSource     string
 	expectedData FileData
 }
 
-var test1 = testCase{
-	name: "simple 1",
-	jsSource: `
+var collectDataTestCases = []collectDataTestCase{
+	{
+		name: "simple 1",
+		jsSource: `
 var a = "hello"
 	`,
-	expectedData: FileData{
-		Identifiers: []token.Identifier{
-			{Name: "a", Type: token.Variable},
+		expectedData: FileData{
+			Identifiers: []token.Identifier{
+				{Name: "a", Type: token.Variable},
+			},
+			StringLiterals: []token.String{
+				{Value: "hello", Raw: `"hello"`},
+			},
+			IntLiterals:   []token.Int{},
+			FloatLiterals: []token.Float{},
 		},
-		StringLiterals: []token.String{
-			{Value: "hello", Raw: `"hello"`},
-		},
-		IntLiterals:   []token.Int{},
-		FloatLiterals: []token.Float{},
 	},
-}
-
-var test2 = testCase{
-	name: "simple 2",
-	jsSource: `
+	{
+		name: "simple 2",
+		jsSource: `
 function test(a, b = 2) {
 	console.log("hello")
 	var c = a + b
@@ -45,23 +45,24 @@ function test(a, b = 2) {
 	}
 }
 	`,
-	expectedData: FileData{
-		Identifiers: []token.Identifier{
-			{Name: "test", Type: token.Function},
-			{Name: "a", Type: token.Parameter},
-			{Name: "b", Type: token.Parameter},
-			{Name: "c", Type: token.Variable},
+		expectedData: FileData{
+			Identifiers: []token.Identifier{
+				{Name: "test", Type: token.Function},
+				{Name: "a", Type: token.Parameter},
+				{Name: "b", Type: token.Parameter},
+				{Name: "c", Type: token.Variable},
+			},
+			StringLiterals: []token.String{
+				{Value: "hello", Raw: `"hello"`},
+				{Value: "apple", Raw: `"apple"`},
+			},
+			IntLiterals: []token.Int{
+				{Value: 2, Raw: "2"},
+				{Value: 3, Raw: "3"},
+				{Value: 4, Raw: "4"},
+			},
+			FloatLiterals: []token.Float{},
 		},
-		StringLiterals: []token.String{
-			{Value: "hello", Raw: `"hello"`},
-			{Value: "apple", Raw: `"apple"`},
-		},
-		IntLiterals: []token.Int{
-			{Value: 2, Raw: "2"},
-			{Value: 3, Raw: "3"},
-			{Value: 4, Raw: "4"},
-		},
-		FloatLiterals: []token.Float{},
 	},
 }
 
@@ -75,8 +76,7 @@ func TestCollectData(t *testing.T) {
 		t.Fatalf("failed to init parser: %v", err)
 	}
 
-	tests := []testCase{test1, test2}
-	for _, tt := range tests {
+	for _, tt := range collectDataTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := CollectData(parserConfig, "", tt.jsSource, false)
 			if err != nil {

--- a/internal/staticanalysis/parsing/js/js_parsing_test.go
+++ b/internal/staticanalysis/parsing/js/js_parsing_test.go
@@ -17,9 +17,10 @@ type jsTestCase struct {
 	printJson bool // set to true to see raw parser output
 }
 
-var test1 = jsTestCase{
-	name: "test string declarations and templates",
-	inputJs: `
+var jsTestCases = []jsTestCase{
+	{
+		name: "test string declarations and templates",
+		inputJs: `
 function test() {
     var mystring1 = "hello1";
     var mystring2 = 'hello2';
@@ -35,67 +36,65 @@ function test() {
 //"'11"'` + "`" + `;
 	var mystring12 = ` + "`hello\"'${5.6 + 6.4}\"'`" + `;
 }`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Function, "test", token.Position{2, 9}},
-			{token.Variable, "mystring1", token.Position{3, 8}},
-			{token.Variable, "mystring2", token.Position{4, 8}},
-			{token.Variable, "mystring3", token.Position{5, 8}},
-			{token.Variable, "mystring4", token.Position{6, 8}},
-			{token.Variable, "mystring5", token.Position{7, 8}},
-			{token.Variable, "mystring6", token.Position{8, 8}},
-			{token.Variable, "mystring7", token.Position{9, 8}},
-			{token.Variable, "mystring8", token.Position{10, 8}},
-			{token.Variable, "mystring9", token.Position{11, 8}},
-			{token.Variable, "mystring10", token.Position{12, 8}},
-			{token.Variable, "mystring11", token.Position{13, 5}},
-			{token.Variable, "mystring12", token.Position{15, 5}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"String", "string", "hello1", `"hello1"`, false, token.Position{3, 20}},
-			{"String", "string", "hello2", `'hello2'`, false, token.Position{4, 20}},
-			{"String", "string", "hello'3'", `"hello'3'"`, false, token.Position{5, 20}},
-			{"String", "string", "hello\"4\"", `'hello"4"'`, false, token.Position{6, 20}},
-			{"String", "string", "hello\"5\"", `"hello\"5\""`, false, token.Position{7, 20}},
-			{"String", "string", "hello'6'", `"hello\'6\'"`, false, token.Position{8, 20}},
-			{"String", "string", "hello'7'", `'hello\'7\''`, false, token.Position{9, 20}},
-			{"String", "string", "hello", `"hello"`, false, token.Position{10, 20}},
-			{"String", "string", "8", `"8"`, false, token.Position{10, 30}},
-			{"StringTemplate", "string", "hello9", `hello9`, false, token.Position{11, 21}},
-			{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{12, 22}},
-			{"StringTemplate", "string", "\"'", `"'`, false, token.Position{12, 34}},
-			{"Numeric", "float64", 10.0, "10", false, token.Position{12, 31}},
-			{"StringTemplate", "string", "hello\n//\"'11\"'", `hello` + "\n" + `//"'11"'`, false, token.Position{13, 19}},
-			{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{15, 19}},
-			{"StringTemplate", "string", "\"'", `"'`, false, token.Position{15, 38}},
-			{"Numeric", "float64", 5.6, "5.6", false, token.Position{15, 28}},
-			{"Numeric", "float64", 6.4, "6.4", false, token.Position{15, 34}},
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Function, "test", token.Position{2, 9}},
+				{token.Variable, "mystring1", token.Position{3, 8}},
+				{token.Variable, "mystring2", token.Position{4, 8}},
+				{token.Variable, "mystring3", token.Position{5, 8}},
+				{token.Variable, "mystring4", token.Position{6, 8}},
+				{token.Variable, "mystring5", token.Position{7, 8}},
+				{token.Variable, "mystring6", token.Position{8, 8}},
+				{token.Variable, "mystring7", token.Position{9, 8}},
+				{token.Variable, "mystring8", token.Position{10, 8}},
+				{token.Variable, "mystring9", token.Position{11, 8}},
+				{token.Variable, "mystring10", token.Position{12, 8}},
+				{token.Variable, "mystring11", token.Position{13, 5}},
+				{token.Variable, "mystring12", token.Position{15, 5}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"String", "string", "hello1", `"hello1"`, false, token.Position{3, 20}},
+				{"String", "string", "hello2", `'hello2'`, false, token.Position{4, 20}},
+				{"String", "string", "hello'3'", `"hello'3'"`, false, token.Position{5, 20}},
+				{"String", "string", "hello\"4\"", `'hello"4"'`, false, token.Position{6, 20}},
+				{"String", "string", "hello\"5\"", `"hello\"5\""`, false, token.Position{7, 20}},
+				{"String", "string", "hello'6'", `"hello\'6\'"`, false, token.Position{8, 20}},
+				{"String", "string", "hello'7'", `'hello\'7\''`, false, token.Position{9, 20}},
+				{"String", "string", "hello", `"hello"`, false, token.Position{10, 20}},
+				{"String", "string", "8", `"8"`, false, token.Position{10, 30}},
+				{"StringTemplate", "string", "hello9", `hello9`, false, token.Position{11, 21}},
+				{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{12, 22}},
+				{"StringTemplate", "string", "\"'", `"'`, false, token.Position{12, 34}},
+				{"Numeric", "float64", 10.0, "10", false, token.Position{12, 31}},
+				{"StringTemplate", "string", "hello\n//\"'11\"'", `hello` + "\n" + `//"'11"'`, false, token.Position{13, 19}},
+				{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{15, 19}},
+				{"StringTemplate", "string", "\"'", `"'`, false, token.Position{15, 38}},
+				{"Numeric", "float64", 5.6, "5.6", false, token.Position{15, 28}},
+				{"Numeric", "float64", 6.4, "6.4", false, token.Position{15, 34}},
+			},
 		},
 	},
-}
-
-var test2 = jsTestCase{
-	name: "test function parameters",
-	inputJs: `
+	{
+		name: "test function parameters",
+		inputJs: `
 function test2(param1, param2, param3 = "ahd") {
 	return param1 + param2 + param3;
 }`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Function, "test2", token.Position{2, 9}},
-			{token.Parameter, "param1", token.Position{2, 15}},
-			{token.Parameter, "param2", token.Position{2, 23}},
-			{token.Parameter, "param3", token.Position{2, 31}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"String", "string", "ahd", `"ahd"`, false, token.Position{2, 40}},
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Function, "test2", token.Position{2, 9}},
+				{token.Parameter, "param1", token.Position{2, 15}},
+				{token.Parameter, "param2", token.Position{2, 23}},
+				{token.Parameter, "param3", token.Position{2, 31}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"String", "string", "ahd", `"ahd"`, false, token.Position{2, 40}},
+			},
 		},
 	},
-}
-
-var test3 = jsTestCase{
-	name: "test control flow",
-	inputJs: `
+	{
+		name: "test control flow",
+		inputJs: `
 function test3(a, b, c) {
     for (var i = a; i < b; i++) {
 outer:
@@ -114,35 +113,34 @@ outer:
     }
     console.log("End");
 }`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Function, "test3", token.Position{2, 9}},
-			{token.Parameter, "a", token.Position{2, 15}},
-			{token.Parameter, "b", token.Position{2, 18}},
-			{token.Parameter, "c", token.Position{2, 21}},
-			{token.Variable, "i", token.Position{3, 13}},
-			{token.StatementLabel, "outer", token.Position{4, 0}},
-			{token.Variable, "j", token.Position{5, 17}},
-			{token.Variable, "k", token.Position{6, 21}},
-			{token.Member, "log", token.Position{16, 16}},
-			{token.Member, "log", token.Position{18, 12}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"Numeric", "float64", 1.0, "1", false, token.Position{5, 21}},
-			{"Numeric", "float64", 3.0, "3", false, token.Position{5, 28}},
-			{"Numeric", "float64", 10.0, "10", false, token.Position{6, 36}},
-			{"Numeric", "float64", 2.0, "2", false, token.Position{7, 26}},
-			{"Numeric", "float64", 32.0, "32", false, token.Position{13, 16}},
-			{"Numeric", "float64", 0.0, "0", false, token.Position{13, 23}},
-			{"String", "string", "here", `"here"`, false, token.Position{16, 20}},
-			{"String", "string", "End", `"End"`, false, token.Position{18, 16}},
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Function, "test3", token.Position{2, 9}},
+				{token.Parameter, "a", token.Position{2, 15}},
+				{token.Parameter, "b", token.Position{2, 18}},
+				{token.Parameter, "c", token.Position{2, 21}},
+				{token.Variable, "i", token.Position{3, 13}},
+				{token.StatementLabel, "outer", token.Position{4, 0}},
+				{token.Variable, "j", token.Position{5, 17}},
+				{token.Variable, "k", token.Position{6, 21}},
+				{token.Member, "log", token.Position{16, 16}},
+				{token.Member, "log", token.Position{18, 12}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"Numeric", "float64", 1.0, "1", false, token.Position{5, 21}},
+				{"Numeric", "float64", 3.0, "3", false, token.Position{5, 28}},
+				{"Numeric", "float64", 10.0, "10", false, token.Position{6, 36}},
+				{"Numeric", "float64", 2.0, "2", false, token.Position{7, 26}},
+				{"Numeric", "float64", 32.0, "32", false, token.Position{13, 16}},
+				{"Numeric", "float64", 0.0, "0", false, token.Position{13, 23}},
+				{"String", "string", "here", `"here"`, false, token.Position{16, 20}},
+				{"String", "string", "End", `"End"`, false, token.Position{18, 16}},
+			},
 		},
 	},
-}
-
-var test4 = jsTestCase{
-	name: "test arrays and exceptions",
-	inputJs: `
+	{
+		name: "test arrays and exceptions",
+		inputJs: `
 function test4() {
     const a = [1, 2, 3];
     try {
@@ -167,42 +165,41 @@ function test4() {
             break;
     }
 }`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Function, "test4", token.Position{2, 9}},
-			{token.Variable, "a", token.Position{3, 10}},
-			{token.Member, "log", token.Position{6, 20}},
-			{token.Member, "log", token.Position{8, 20}},
-			{token.Member, "log", token.Position{10, 20}},
-			{token.Parameter, "e", token.Position{12, 13}},
-			{token.Variable, "f", token.Position{13, 12}},
-			{token.Member, "log", token.Position{14, 16}},
-			{token.Member, "log", token.Position{19, 20}},
-			{token.Member, "log", token.Position{22, 20}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"Numeric", "float64", 1.0, "1", true, token.Position{3, 15}},
-			{"Numeric", "float64", 2.0, "2", true, token.Position{3, 18}},
-			{"Numeric", "float64", 3.0, "3", true, token.Position{3, 21}},
-			{"Numeric", "float64", 1.0, "1", false, token.Position{5, 14}},
-			{"Numeric", "float64", 3.0, "3", false, token.Position{5, 21}},
-			{"Numeric", "float64", 1.0, "1", false, token.Position{6, 27}},
-			{"Numeric", "float64", 1.0, "1", false, token.Position{7, 21}},
-			{"Numeric", "float64", 2.0, "2", false, token.Position{7, 28}},
-			{"Numeric", "float64", 1.0, "1", false, token.Position{8, 26}},
-			{"Numeric", "float64", 2.0, "2", false, token.Position{10, 26}},
-			{"String", "string", "abc", `"abc"`, false, token.Position{13, 16}},
-			{"Numeric", "float64", 0.0, "0", false, token.Position{17, 14}},
-			{"Numeric", "float64", 1.0, "1", false, token.Position{18, 13}},
-			{"String", "string", "Hp", `"Hp"`, false, token.Position{19, 24}},
-			{"String", "string", "Hq", `"Hq"`, false, token.Position{22, 24}},
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Function, "test4", token.Position{2, 9}},
+				{token.Variable, "a", token.Position{3, 10}},
+				{token.Member, "log", token.Position{6, 20}},
+				{token.Member, "log", token.Position{8, 20}},
+				{token.Member, "log", token.Position{10, 20}},
+				{token.Parameter, "e", token.Position{12, 13}},
+				{token.Variable, "f", token.Position{13, 12}},
+				{token.Member, "log", token.Position{14, 16}},
+				{token.Member, "log", token.Position{19, 20}},
+				{token.Member, "log", token.Position{22, 20}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"Numeric", "float64", 1.0, "1", true, token.Position{3, 15}},
+				{"Numeric", "float64", 2.0, "2", true, token.Position{3, 18}},
+				{"Numeric", "float64", 3.0, "3", true, token.Position{3, 21}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{5, 14}},
+				{"Numeric", "float64", 3.0, "3", false, token.Position{5, 21}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{6, 27}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{7, 21}},
+				{"Numeric", "float64", 2.0, "2", false, token.Position{7, 28}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{8, 26}},
+				{"Numeric", "float64", 2.0, "2", false, token.Position{10, 26}},
+				{"String", "string", "abc", `"abc"`, false, token.Position{13, 16}},
+				{"Numeric", "float64", 0.0, "0", false, token.Position{17, 14}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{18, 13}},
+				{"String", "string", "Hp", `"Hp"`, false, token.Position{19, 24}},
+				{"String", "string", "Hq", `"Hq"`, false, token.Position{22, 24}},
+			},
 		},
 	},
-}
-
-var test5 = jsTestCase{
-	name: "test class definition",
-	inputJs: `
+	{
+		name: "test class definition",
+		inputJs: `
 // unnamed
 let Rectangle = class {
     constructor(height, width) {
@@ -224,26 +221,167 @@ Rectangle = class Rectangle2 {
 console.log(Rectangle.name);
 // output: "Rectangle2"
 `,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Variable, "Rectangle", token.Position{3, 4}},
-			{token.Parameter, "height", token.Position{4, 16}},
-			{token.Parameter, "width", token.Position{4, 24}},
-			{token.Member, "height", token.Position{5, 13}},
-			{token.Member, "width", token.Position{6, 13}},
-			{token.Member, "log", token.Position{9, 8}},
-			{token.Member, "name", token.Position{9, 22}},
-			//{Variable, "Rectangle", Position{4, 22}},
-			{token.Class, "Rectangle2", token.Position{13, 18}},
-			{token.Property, "test", token.Position{14, 5}},
-			{token.Parameter, "height", token.Position{15, 16}},
-			{token.Parameter, "width", token.Position{15, 24}},
-			{token.Member, "height", token.Position{16, 13}},
-			{token.Member, "width", token.Position{17, 13}},
-			{token.Member, "log", token.Position{20, 8}},
-			{token.Member, "name", token.Position{20, 22}},
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Variable, "Rectangle", token.Position{3, 4}},
+				{token.Parameter, "height", token.Position{4, 16}},
+				{token.Parameter, "width", token.Position{4, 24}},
+				{token.Member, "height", token.Position{5, 13}},
+				{token.Member, "width", token.Position{6, 13}},
+				{token.Member, "log", token.Position{9, 8}},
+				{token.Member, "name", token.Position{9, 22}},
+				//{Variable, "Rectangle", Position{4, 22}},
+				{token.Class, "Rectangle2", token.Position{13, 18}},
+				{token.Property, "test", token.Position{14, 5}},
+				{token.Parameter, "height", token.Position{15, 16}},
+				{token.Parameter, "width", token.Position{15, 24}},
+				{token.Member, "height", token.Position{16, 13}},
+				{token.Member, "width", token.Position{17, 13}},
+				{token.Member, "log", token.Position{20, 8}},
+				{token.Member, "name", token.Position{20, 22}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{},
 		},
-		Literals: []parsing.ParsedLiteral[any]{},
+	},
+	{
+		name: "test class definition",
+		inputJs: `
+// unnamed
+let Rectangle = class {
+    constructor(height, width) {
+        this.height = height;
+        this.width = width;
+    }
+};
+console.log(Rectangle.name);
+// output: "Rectangle"
+
+// named
+Rectangle = class Rectangle2 {
+    #test = false;
+    constructor(height, width) {
+        this.height = height;
+        this.width = width;
+    }
+};
+console.log(Rectangle.name);
+// output: "Rectangle2"
+`,
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Variable, "Rectangle", token.Position{3, 4}},
+				{token.Parameter, "height", token.Position{4, 16}},
+				{token.Parameter, "width", token.Position{4, 24}},
+				{token.Member, "height", token.Position{5, 13}},
+				{token.Member, "width", token.Position{6, 13}},
+				{token.Member, "log", token.Position{9, 8}},
+				{token.Member, "name", token.Position{9, 22}},
+				//{Variable, "Rectangle", Position{4, 22}},
+				{token.Class, "Rectangle2", token.Position{13, 18}},
+				{token.Property, "test", token.Position{14, 5}},
+				{token.Parameter, "height", token.Position{15, 16}},
+				{token.Parameter, "width", token.Position{15, 24}},
+				{token.Member, "height", token.Position{16, 13}},
+				{token.Member, "width", token.Position{17, 13}},
+				{token.Member, "log", token.Position{20, 8}},
+				{token.Member, "name", token.Position{20, 22}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{},
+		},
+	},
+	{
+		name: "test exotic assignments",
+		inputJs: `
+let [a, b] = [1, 2];
+let [_, c] = [3, 4];
+var index = 0,
+    completed = 0,
+    {length, width} = 10,
+    cancelled = false;
+`,
+		want: parsing.ParseResult{
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Variable, "a", token.Position{2, 5}},
+				{token.Variable, "b", token.Position{2, 8}},
+				{token.Variable, "_", token.Position{3, 5}},
+				{token.Variable, "c", token.Position{3, 8}},
+				{token.Variable, "index", token.Position{4, 4}},
+				{token.Variable, "completed", token.Position{5, 4}},
+				{token.Variable, "length", token.Position{6, 5}},
+				{token.Variable, "width", token.Position{6, 13}},
+				{token.Variable, "cancelled", token.Position{7, 4}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"Numeric", "float64", 1.0, "1", true, token.Position{2, 14}},
+				{"Numeric", "float64", 2.0, "2", true, token.Position{2, 17}},
+				{"Numeric", "float64", 3.0, "3", true, token.Position{3, 14}},
+				{"Numeric", "float64", 4.0, "4", true, token.Position{3, 17}},
+				{"Numeric", "float64", 0.0, "0", false, token.Position{4, 12}},
+				{"Numeric", "float64", 0.0, "0", false, token.Position{5, 16}},
+				{"Numeric", "float64", 10.0, "10", false, token.Position{6, 22}},
+			},
+		},
+	},
+	{
+		name: "test regex literal",
+		inputJs: `
+function validateIPAddress(ipaddress) {
+	const regex = /(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/
+    if (regex.test(ipaddress) || ipaddress.toLowerCase().includes('localhost')) {
+        return (true)
+    }
+
+    return (false)
+}
+`,
+		want: parsing.ParseResult{
+			ValidInput: true,
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Function, "validateIPAddress", token.Position{2, 9}},
+				{token.Parameter, "ipaddress", token.Position{2, 27}},
+				{token.Variable, "regex", token.Position{3, 7}},
+				{token.Member, "test", token.Position{4, 14}},
+				{token.Member, "toLowerCase", token.Position{4, 43}},
+				{token.Member, "includes", token.Position{4, 57}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{
+					Type:     "Regexp",
+					GoType:   "string",
+					Value:    "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
+					RawValue: "/(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/",
+					InArray:  false,
+					Pos:      token.Position{3, 15},
+				},
+				{"String", "string", "localhost", "'localhost'", false, token.Position{4, 66}},
+			},
+		},
+		printJson: true,
+	},
+	{
+		name: "test big integers",
+		inputJs: `
+let a = 123456789123456789n;     // 123456789123456789
+let b = 0o777777777777n;         // 68719476735
+let c = 0x123456789ABCDEFn;      // 81985529216486895
+let d = 0b11101001010101010101n; // 955733
+`,
+		want: parsing.ParseResult{
+			ValidInput: true,
+			Identifiers: []parsing.ParsedIdentifier{
+				{token.Variable, "a", token.Position{2, 4}},
+				{token.Variable, "b", token.Position{3, 4}},
+				{token.Variable, "c", token.Position{4, 4}},
+				{token.Variable, "d", token.Position{5, 4}},
+			},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"Numeric", "big.Int", big.NewInt(123456789123456789), "123456789123456789n", false, token.Position{2, 8}},
+				{"Numeric", "big.Int", big.NewInt(68719476735), "0o777777777777n", false, token.Position{3, 8}},
+				{"Numeric", "big.Int", big.NewInt(81985529216486895), "0x123456789ABCDEFn", false, token.Position{4, 8}},
+				{"Numeric", "big.Int", big.NewInt(955733), "0b11101001010101010101n", false, token.Position{5, 8}},
+			},
+		},
+		printJson: false,
 	},
 }
 
@@ -264,117 +402,19 @@ console.log("Hello");
 	},
 }
 
-var test7 = jsTestCase{
-	name: "test exotic assignments",
-	inputJs: `
-let [a, b] = [1, 2];
-let [_, c] = [3, 4];
-var index = 0,
-    completed = 0,
-    {length, width} = 10,
-    cancelled = false;
-`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Variable, "a", token.Position{2, 5}},
-			{token.Variable, "b", token.Position{2, 8}},
-			{token.Variable, "_", token.Position{3, 5}},
-			{token.Variable, "c", token.Position{3, 8}},
-			{token.Variable, "index", token.Position{4, 4}},
-			{token.Variable, "completed", token.Position{5, 4}},
-			{token.Variable, "length", token.Position{6, 5}},
-			{token.Variable, "width", token.Position{6, 13}},
-			{token.Variable, "cancelled", token.Position{7, 4}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"Numeric", "float64", 1.0, "1", true, token.Position{2, 14}},
-			{"Numeric", "float64", 2.0, "2", true, token.Position{2, 17}},
-			{"Numeric", "float64", 3.0, "3", true, token.Position{3, 14}},
-			{"Numeric", "float64", 4.0, "4", true, token.Position{3, 17}},
-			{"Numeric", "float64", 0.0, "0", false, token.Position{4, 12}},
-			{"Numeric", "float64", 0.0, "0", false, token.Position{5, 16}},
-			{"Numeric", "float64", 10.0, "10", false, token.Position{6, 22}},
-		},
-	},
-}
-
-var test8 = jsTestCase{
-	name: "test regex literal",
-	inputJs: `
-function validateIPAddress(ipaddress) {
-	const regex = /(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/
-    if (regex.test(ipaddress) || ipaddress.toLowerCase().includes('localhost')) {
-        return (true)
-    }
-
-    return (false)
-}
-`,
-	want: parsing.ParseResult{
-		ValidInput: true,
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Function, "validateIPAddress", token.Position{2, 9}},
-			{token.Parameter, "ipaddress", token.Position{2, 27}},
-			{token.Variable, "regex", token.Position{3, 7}},
-			{token.Member, "test", token.Position{4, 14}},
-			{token.Member, "toLowerCase", token.Position{4, 43}},
-			{token.Member, "includes", token.Position{4, 57}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{
-				Type:     "Regexp",
-				GoType:   "string",
-				Value:    "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
-				RawValue: "/(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/",
-				InArray:  false,
-				Pos:      token.Position{3, 15},
-			},
-			{"String", "string", "localhost", "'localhost'", false, token.Position{4, 66}},
-		},
-	},
-	printJson: true,
-}
-
-var test9 = jsTestCase{
-	name: "test big integers",
-	inputJs: `
-let a = 123456789123456789n;     // 123456789123456789
-let b = 0o777777777777n;         // 68719476735
-let c = 0x123456789ABCDEFn;      // 81985529216486895
-let d = 0b11101001010101010101n; // 955733
-`,
-	want: parsing.ParseResult{
-		ValidInput: true,
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Variable, "a", token.Position{2, 4}},
-			{token.Variable, "b", token.Position{3, 4}},
-			{token.Variable, "c", token.Position{4, 4}},
-			{token.Variable, "d", token.Position{5, 4}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"Numeric", "big.Int", big.NewInt(123456789123456789), "123456789123456789n", false, token.Position{2, 8}},
-			{"Numeric", "big.Int", big.NewInt(68719476735), "0o777777777777n", false, token.Position{3, 8}},
-			{"Numeric", "big.Int", big.NewInt(81985529216486895), "0x123456789ABCDEFn", false, token.Position{4, 8}},
-			{"Numeric", "big.Int", big.NewInt(955733), "0b11101001010101010101n", false, token.Position{5, 8}},
-		},
-	},
-	printJson: false,
-}
-
 func init() {
 	log.Initialize("")
 }
 
 func TestParseJS(t *testing.T) {
 	const printAllJson = false
-	var tests = []jsTestCase{test1, test2, test3, test4, test5, test6, test7, test8, test9}
 
 	jsParserConfig, err := InitParser(t.TempDir())
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 
-	for _, tt := range tests {
+	for _, tt := range jsTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, parserOutput, err := ParseJS(jsParserConfig, "", tt.inputJs)
 			if err != nil {

--- a/internal/staticanalysis/parsing/js/js_parsing_test.go
+++ b/internal/staticanalysis/parsing/js/js_parsing_test.go
@@ -244,49 +244,19 @@ console.log(Rectangle.name);
 		},
 	},
 	{
-		name: "test class definition",
+		name: "test use strict",
 		inputJs: `
-// unnamed
-let Rectangle = class {
-    constructor(height, width) {
-        this.height = height;
-        this.width = width;
-    }
-};
-console.log(Rectangle.name);
-// output: "Rectangle"
-
-// named
-Rectangle = class Rectangle2 {
-    #test = false;
-    constructor(height, width) {
-        this.height = height;
-        this.width = width;
-    }
-};
-console.log(Rectangle.name);
-// output: "Rectangle2"
+'use strict';
+console.log("Hello");
 `,
 		want: parsing.ParseResult{
 			Identifiers: []parsing.ParsedIdentifier{
-				{token.Variable, "Rectangle", token.Position{3, 4}},
-				{token.Parameter, "height", token.Position{4, 16}},
-				{token.Parameter, "width", token.Position{4, 24}},
-				{token.Member, "height", token.Position{5, 13}},
-				{token.Member, "width", token.Position{6, 13}},
-				{token.Member, "log", token.Position{9, 8}},
-				{token.Member, "name", token.Position{9, 22}},
-				//{Variable, "Rectangle", Position{4, 22}},
-				{token.Class, "Rectangle2", token.Position{13, 18}},
-				{token.Property, "test", token.Position{14, 5}},
-				{token.Parameter, "height", token.Position{15, 16}},
-				{token.Parameter, "width", token.Position{15, 24}},
-				{token.Member, "height", token.Position{16, 13}},
-				{token.Member, "width", token.Position{17, 13}},
-				{token.Member, "log", token.Position{20, 8}},
-				{token.Member, "name", token.Position{20, 22}},
+				{token.Member, "log", token.Position{3, 8}},
 			},
-			Literals: []parsing.ParsedLiteral[any]{},
+			Literals: []parsing.ParsedLiteral[any]{
+				{"String", "string", "use strict", `'use strict'`, false, token.Position{2, 0}},
+				{"String", "string", "Hello", `"Hello"`, false, token.Position{3, 12}},
+			},
 		},
 	},
 	{
@@ -382,23 +352,6 @@ let d = 0b11101001010101010101n; // 955733
 			},
 		},
 		printJson: false,
-	},
-}
-
-var test6 = jsTestCase{
-	name: "test use strict",
-	inputJs: `
-'use strict';
-console.log("Hello");
-`,
-	want: parsing.ParseResult{
-		Identifiers: []parsing.ParsedIdentifier{
-			{token.Member, "log", token.Position{3, 8}},
-		},
-		Literals: []parsing.ParsedLiteral[any]{
-			{"String", "string", "use strict", `'use strict'`, false, token.Position{2, 0}},
-			{"String", "string", "Hello", `"Hello"`, false, token.Position{3, 12}},
-		},
 	},
 }
 


### PR DESCRIPTION
Part 1 of #614 

- declare all cases in a single struct rather than variables for each test case. This reduces unnecessary names in the code.
- use parse results directly in compute_signals_test.go rather than having to regenerate them from parsing (and thus implicitly testing parsing)

Review note: it's a lot easier if you use the 'hide whitespace' option when viewing the diff

Signed-off-by: Max Fisher <maxfisher@google.com>