### PR TITLE
Add Stringify function for pkgIdentifier

### DIFF
--- a/pkg/pkgidentifier/pkgidentifier.go
+++ b/pkg/pkgidentifier/pkgidentifier.go
@@ -1,7 +1,15 @@
 package pkgidentifier
 
+import (
+	"strings"
+)
+
 type PkgIdentifier struct {
 	Name		string
 	Version 	string
 	Ecosystem	string
+}
+
+func (pkg PkgIdentifier) String() string {
+	return strings.Join([]string{pkg.Ecosystem, pkg.Name, pkg.Version}, "-")
 }

--- a/pkg/pkgidentifier/pkgidentifier_test.go
+++ b/pkg/pkgidentifier/pkgidentifier_test.go
@@ -1,0 +1,35 @@
+package pkgidentifier
+
+import (
+	"testing"
+)
+
+func TestStringify(t *testing.T) {
+	var tests = map[string]struct {
+		input PkgIdentifier
+		expected string
+	} {
+		"simple stringify":  {
+			input: PkgIdentifier{Name:"genericpackage" ,Version:"2.05.0", Ecosystem:"npm"},
+			expected: "npm-genericpackage-2.05.0",
+		},
+		"pkg name with space":  {
+			input: PkgIdentifier{Name:"cool package" ,Version:"1.0.0", Ecosystem:"pypi"},
+			expected: "pypi-cool package-1.0.0",
+		},
+		"pkg name with forward slash":  {
+			input: PkgIdentifier{Name:"@ada/evilpackage" ,Version:"99.0.0", Ecosystem:"npm"},
+			expected: "npm-@ada/evilpackage-99.0.0",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.input.String()
+			expected := test.expected
+			if got != expected {
+				t.Fatalf("%v: returned %v; expected %v", name, got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a .String() method for the pkgIdentifier struct.

This is used to prettyprint and as part of functions to generate file paths in Package Detection.

Signed-off-by: Ada Luong <adaluong@google.com>