### PR TITLE
Parsing restructure and improvements

### DIFF
--- a/internal/staticanalysis/parsing/babel-parser.js
+++ b/internal/staticanalysis/parsing/babel-parser.js
@@ -11,75 +11,79 @@ import _traverse from "@babel/traverse";
 
 const traverse = _traverse.default;
 
-// If the parser encounters an unrecoverable syntax error (which may indicate
-// that the input is not JavaScript, the program will exit with this exit code.
-const SYNTAX_ERROR_EXIT_CODE = 33;
+// used to signal to parent process that parsing could not complete due to syntax errors
+const fatalSyntaxErrorMarker = "FATAL SYNTAX ERROR";
 
-function locationString(node) {
-    return (node.loc !== null) ? `[${node.loc.start.line},${node.loc.start.column}]` : "[]";
+function position(node) {
+    return (node.loc !== null) ? [node.loc.start.line,node.loc.start.column] : [];
 }
 
-const parseOutputLines = [];
+// Holds all parsing data for a single file
+class ParseData {
+    constructor() {
+        // holds symbol information (function, variable names)
+        this.symbols = [];
+        // holds status information (info, errors)
+        this.status = [];
+    }
 
-function logJSON(type, subtype, data, pos, extra = null) {
-    const extraValue = (extra !== null) ? `${JSON.stringify(extra)}` : "{}";
-    const json = `{"type":"${type}","subtype":"${subtype}","data":${JSON.stringify(data)},` +
-        `"pos":${pos},"extra":${extraValue}}`;
-    parseOutputLines.push(json);
-}
+    static makeOutputDict(type, subtype, data, pos, extra = null) {
+        return { "type": type, "subtype": subtype, data: data, pos: pos, extra: (extra === null) ? {} : extra };
+    }
 
-function logError(errorType, message, pos) {
-    logJSON("Error", errorType, message, pos);
-}
+    logError(errorType, message, pos) {
+        this.status.push(ParseData.makeOutputDict("Error", errorType, message, pos));
+    }
 
-function logInfo(infoType, message) {
-    logJSON("Info", infoType, message, "[]");
-}
+    logInfo(infoType, message) {
+        this.status.push(ParseData.makeOutputDict("Info", infoType, message, []));
+    }
 
-function logComment(commentType, comment, pos) {
-    logJSON("Comment", commentType, comment, pos);
-}
+    logComment(commentType, comment, pos) {
+        this.symbols.push(ParseData.makeOutputDict("Comment", commentType, comment, pos));
+    }
 
-function logIdentifierOrPrivateName(identifierType, node) {
-    // if node is a PrivateName, the corresponding Identifier can be found as node.id
-    let identifierNode;
-    switch (node.type) {
-        case "Identifier":
-            identifierNode = node;
-            break;
-        case "PrivateName":
-            identifierNode = node.id;
-            break;
-        default:
-            console.log("Error: logIdentifierNodeJSON passed a node of type " + node.type);
+    logIdentifierOrPrivateName(identifierType, node) {
+        // if node is a PrivateName, the corresponding Identifier can be found as node.id
+        let identifierNode;
+        switch (node.type) {
+            case "Identifier":
+                identifierNode = node;
+                break;
+            case "PrivateName":
+                identifierNode = node.id;
+                break;
+            default:
+                console.log("Error: logIdentifierNodeJSON passed a node of type " + node.type);
+                return;
+        }
+
+        let name = identifierNode.name;
+        let pos = position(identifierNode);
+
+        if (identifierNode.name === undefined) {
+            console.log("Error: undefined identifier name at pos " + pos);
+        }
+
+        this.symbols.push(ParseData.makeOutputDict("Identifier", identifierType, name, pos));
+    }
+
+    logLiteral(literalType, value, pos, inArray, extra = null) {
+        if (value === undefined) {
+            console.log("Error: undefined literal value at pos " + pos);
             return;
+        }
+
+        if (extra === null) {
+            extra = {};
+        }
+
+        extra.array = inArray;
+        this.symbols.push(ParseData.makeOutputDict("Literal", literalType, value, pos, extra));
     }
-
-    let name = identifierNode.name;
-    let pos = locationString(identifierNode);
-
-    if (identifierNode.name === undefined) {
-        console.log("Error: undefined identifier name at pos " + pos);
-    }
-
-    logJSON("Identifier", identifierType, name, pos);
 }
 
-function logLiteral(literalType, value, pos, inArray, extra = null) {
-    if (value === undefined) {
-        console.log("Error: undefined literal value at pos " + pos);
-        return;
-    }
-
-    if (extra === null) {
-        extra = {};
-    }
-
-    extra.array = inArray;
-    logJSON("Literal", literalType, value, pos, extra);
-}
-
-function visitIdentifierOrPrivateName(path) {
+function visitIdentifierOrPrivateName(path, parseData) {
     const node = path.node;
     const parentNode = path.parentPath.node;
     const parentParentNode = path.parentPath.parentPath.node;
@@ -87,67 +91,67 @@ function visitIdentifierOrPrivateName(path) {
     switch (parentNode.type) {
         case "ObjectProperty":
             if (node === parentNode.key) {
-                logIdentifierOrPrivateName("Variable", node);
+                parseData.logIdentifierOrPrivateName("Variable", node);
             }
             break;
         case "ArrayPattern":
-            logIdentifierOrPrivateName("Variable", node);
+            parseData.logIdentifierOrPrivateName("Variable", node);
             break;
         case "VariableDeclarator":
             if (node === parentNode.id) {
-                logIdentifierOrPrivateName("Variable", node);
+                parseData.logIdentifierOrPrivateName("Variable", node);
             }
             break;
         case "FunctionDeclaration":
             if (node === parentNode.id) {
-                logIdentifierOrPrivateName("Function", node);
+                parseData.logIdentifierOrPrivateName("Function", node);
             } else {
-                logIdentifierOrPrivateName("Parameter", node);
+                parseData.logIdentifierOrPrivateName("Parameter", node);
             }
             break;
         case "LabeledStatement":
-            logIdentifierOrPrivateName("StatementLabel", node);
+            parseData.logIdentifierOrPrivateName("StatementLabel", node);
             break;
         case "PrivateName":
             // processed already
             break;
         case "MemberExpression":
             if (node === parentNode.property) {
-                logIdentifierOrPrivateName("Member", node);
+                parseData.logIdentifierOrPrivateName("Member", node);
             }
             break;
         case "CatchClause":
-            logIdentifierOrPrivateName("Parameter", node);
+            parseData.logIdentifierOrPrivateName("Parameter", node);
             break;
         case "ClassPrivateMethod":
             // fall through
         case "ClassMethod":
             if (node === parentNode.key) {
                 if (parentNode.kind !== "constructor") {
-                    logIdentifierOrPrivateName("Method", node);
+                    parseData.logIdentifierOrPrivateName("Method", node);
                 }
             } else {
-                logIdentifierOrPrivateName("Parameter", node);
+                parseData.logIdentifierOrPrivateName("Parameter", node);
             }
             break;
         case "ClassPrivateProperty":
             // fall through
         case "ClassProperty":
-            logIdentifierOrPrivateName("Property", node);
+            parseData.logIdentifierOrPrivateName("Property", node);
             break;
         case "AssignmentPattern":
             if (node === parentNode.left && parentParentNode.type === "FunctionDeclaration") {
                 // function parameter with default value
-                logIdentifierOrPrivateName("Parameter", node);
+                parseData.logIdentifierOrPrivateName("Parameter", node);
             }
             break;
         case "AssignmentExpression":
             if (node === parentNode.left) {
-                logIdentifierOrPrivateName("AssignmentTarget", node);
+                parseData.logIdentifierOrPrivateName("AssignmentTarget", node);
             }
             break;
         case "ClassExpression":
-            logIdentifierOrPrivateName("Class", node);
+            parseData.logIdentifierOrPrivateName("Class", node);
             break;
     }
 }
@@ -157,7 +161,7 @@ function visitIdentifierOrPrivateName(path) {
  In particular, this redeclared variables from crashing the traversal
  when the AST was produced from parsing with errorRecovery: true.
  */
-function traverseAst(ast, disableScope) {
+function traverseAst(ast, parseData, disableScope) {
     /*
       TODO
        1. Consider adding state to allow distinction between elements from different arrays
@@ -166,92 +170,74 @@ function traverseAst(ast, disableScope) {
     const arrayVisitor = {
         noScope: disableScope,
         StringLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("String", path.node.value, loc, true, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("String", path.node.value, loc, true, path.node.extra);
         },
         NumericLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("Numeric", path.node.value, loc, true, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Numeric", path.node.value, loc, true, path.node.extra);
         },
         BigIntLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("Numeric", path.node.value, loc, true, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Numeric", path.node.value, loc, true, path.node.extra);
         },
         RegExpLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("Regexp", path.node.pattern, loc, true, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Regexp", path.node.pattern, loc, true, path.node.extra);
         },
         TemplateElement: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("StringTemplate", path.node.value.raw, loc, true, path.node.value);
+            const loc = position(path.node);
+            this.parseData.logLiteral("StringTemplate", path.node.value.raw, loc, true, path.node.value);
         }
     };
 
     const astVisitor = {
         noScope: disableScope,
-        Identifier: visitIdentifierOrPrivateName,
-        PrivateName: visitIdentifierOrPrivateName,
+        Identifier: function (path) {
+            visitIdentifierOrPrivateName(path, this.parseData);
+        },
+        PrivateName: function (path) {
+            visitIdentifierOrPrivateName(path, this.parseData);
+        },
         StringLiteral: function (path) {
-            const loc = locationString(path.node);
-            logLiteral("String", path.node.value, loc, false, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("String", path.node.value, loc, false, path.node.extra);
         },
         DirectiveLiteral: function (path) {
             // same as string literal
-            const loc = locationString(path.node);
-            logLiteral("String", path.node.value, loc, false, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("String", path.node.value, loc, false, path.node.extra);
         },
         NumericLiteral: function (path) {
-            const loc = locationString(path.node);
-            logLiteral("Numeric", path.node.value, loc, false, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Numeric", path.node.value, loc, false, path.node.extra);
         },
         BigIntLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("Numeric", path.node.value, loc, false, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Numeric", path.node.value, loc, false, path.node.extra);
         },
         RegExpLiteral: function(path) {
-            const loc = locationString(path.node);
-            logLiteral("Regexp", path.node.pattern, loc, false, path.node.extra);
+            const loc = position(path.node);
+            this.parseData.logLiteral("Regexp", path.node.pattern, loc, false, path.node.extra);
         },
         ArrayExpression: function (path) {
-            path.traverse(arrayVisitor);
+            path.traverse(arrayVisitor, { parseData });
             path.skip();
         },
         TemplateElement: function (path) {
-            const loc = locationString(path.node);
-            logLiteral("StringTemplate", path.node.value.raw, loc, false, path.node.value);
+            const loc = position(path.node);
+            this.parseData.logLiteral("StringTemplate", path.node.value.raw, loc, false, path.node.value);
         }
     };
 
-    traverse(ast, astVisitor);
+    traverse(ast, astVisitor, null, { parseData });
 }
 
-function main() {
-    /*
-     If false, syntax errors result in immediate termination of the program with
-     SYNTAX_ERROR_EXIT_CODE, and JSON output will be suppressed.
-     If true, the parser will recover from minor syntax errors where possible, and
-     record error details in the output JSON. If not possible to recover, the program
-     will still terminate with SYNTAX_ERROR_EXIT_CODE.
-     */
-    let allowSyntaxErrors = false;
+function parseFile(fileName, allowSyntaxErrors, includeAST) {
+    const sourceCode = fs.readFileSync(fileName, "utf8");
 
-    let printDebug = false;
-
-    /*
-     Referencing process.stdin.fd (actually just process.stdin) causes stdin to become nonblocking
-     Therefore running this in a terminal in interactive mode with no file piped into stdin will
-     cause the read to fail with EAGAIN. Passing the raw '0' as the fd avoids this issue.
-     See https://github.com/nodejs/help/issues/2663
-     */
-    const sourceFile = process.argv.length >= 3 ? process.argv[2] : 0;
-    if (process.argv[process.argv.length - 1] === "debug") {
-        printDebug = true;
-    }
-
-    const sourceCode = fs.readFileSync(sourceFile, "utf8");
-    logInfo("InputLength", sourceCode.length);
-
-    let unrecoverableSyntaxError = false;
+    const parseData = new ParseData();
+    parseData.logInfo("InputLength", sourceCode.length.toString());
 
     try {
         const ast = parser.parse(sourceCode, {
@@ -259,43 +245,62 @@ function main() {
             sourceType: "unambiguous" // parser is allowed to parse input as either script or module
         });
 
-        if (printDebug) {
-            console.log("AST");
-            console.log(JSON.stringify(ast, null, "  "));
+        if (includeAST) {
+            parseData.ast = ast;
         }
 
         for (let e of ast.errors) {
             let pos = `[${e.loc.line},${e.loc.column}]`;
-            logError(e.name, `${e.code}: ${e.reasonCode}`, pos);
+            parseData.logError(e.name, `${e.code}: ${e.reasonCode}`, pos);
         }
 
         for (let c of ast.comments) {
-            let loc = locationString(c);
-            logComment(c.type, c.value, loc);
+            let loc = position(c);
+            parseData.logComment(c.type, c.value, loc);
         }
 
-        traverseAst(ast, allowSyntaxErrors);
+        traverseAst(ast, parseData, allowSyntaxErrors);
 
     } catch (e) {
         if (e instanceof SyntaxError) {
-            unrecoverableSyntaxError = true;
-            let pos = `[${e.loc.line},${e.loc.column}]`;
-            logError(e.name, `${e.code}: ${e.reasonCode}`, pos);
+            let pos = [e.loc.line, e.loc.column];
+            parseData.logError(e.name, `${e.code}: ${e.reasonCode}`, pos);
+            parseData.logError(e.name, `${fatalSyntaxErrorMarker} (unable to parse remainder of file)`, pos);
         } else {
             throw(e);
         }
     }
 
-    const allJSON = "[\n" + parseOutputLines.join(",\n") + "\n]";
+    return parseData;
+}
 
-    const suppressJSON = !allowSyntaxErrors && unrecoverableSyntaxError;
-    if (!suppressJSON) {
-        console.log(allJSON);
+function main() {
+    /*
+     If allowSyntaxErrors is false, any syntax error results in immediate termination
+     of parsing for a file. If true, the parser will recover from minor syntax errors
+     where possible. All error details are recorded in the returned parseData object.
+     */
+    let allowSyntaxErrors = false;
+
+    let printDebug = false;
+
+    /*
+     Use stdin if no filename is specified.
+
+     Referencing process.stdin.fd (actually just process.stdin) causes stdin to become nonblocking
+     Therefore running this in a terminal in interactive mode with no file piped into stdin will
+     cause the read to fail with EAGAIN. Passing the raw '0' as the fd avoids this issue.
+     See https://github.com/nodejs/help/issues/2663
+     */
+    const sourceFile = process.argv.length >= 3 ? process.argv[2] : 0;
+
+    if (process.argv[process.argv.length - 1] === "debug") {
+        printDebug = true;
     }
 
-    if (unrecoverableSyntaxError) {
-        process.exit(SYNTAX_ERROR_EXIT_CODE);
-    }
+    const parseData = parseFile(sourceFile, allowSyntaxErrors, printDebug);
+
+    console.log(JSON.stringify(parseData, null, "  "));
 }
 
 main();

--- a/internal/staticanalysis/parsing/babel-parser.js
+++ b/internal/staticanalysis/parsing/babel-parser.js
@@ -21,8 +21,8 @@ function position(node) {
 // Holds all parsing data for a single file
 class ParseData {
     constructor() {
-        // holds symbol information (function, variable names)
-        this.symbols = [];
+        // holds token information (function, variable names)
+        this.tokens = [];
         // holds status information (info, errors)
         this.status = [];
     }
@@ -40,7 +40,7 @@ class ParseData {
     }
 
     logComment(commentType, comment, pos) {
-        this.symbols.push(ParseData.makeOutputDict("Comment", commentType, comment, pos));
+        this.tokens.push(ParseData.makeOutputDict("Comment", commentType, comment, pos));
     }
 
     logIdentifierOrPrivateName(identifierType, node) {
@@ -65,7 +65,7 @@ class ParseData {
             console.log("Error: undefined identifier name at pos " + pos);
         }
 
-        this.symbols.push(ParseData.makeOutputDict("Identifier", identifierType, name, pos));
+        this.tokens.push(ParseData.makeOutputDict("Identifier", identifierType, name, pos));
     }
 
     logLiteral(literalType, value, pos, inArray, extra = null) {
@@ -79,7 +79,7 @@ class ParseData {
         }
 
         extra.array = inArray;
-        this.symbols.push(ParseData.makeOutputDict("Literal", literalType, value, pos, extra));
+        this.tokens.push(ParseData.makeOutputDict("Literal", literalType, value, pos, extra));
     }
 }
 

--- a/internal/staticanalysis/parsing/js_parsing.go
+++ b/internal/staticanalysis/parsing/js_parsing.go
@@ -11,8 +11,13 @@ import (
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
 
-// parserOutputElement represents the output JSON format of the JS parser
-type parserOutputElement struct {
+// parseOutput represents the output JSON format of the JS parser
+type parseDataJSON struct {
+	Symbols []parseDataJSONElement `json:"symbols"`
+	Status  []parseDataJSONElement `json:"status"`
+}
+
+type parseDataJSONElement struct {
 	SymbolType    SymbolType     `json:"type"`
 	SymbolSubtype string         `json:"subtype"`
 	Data          any            `json:"data"`
@@ -20,23 +25,22 @@ type parserOutputElement struct {
 	Extra         map[string]any `json:"extra"`
 }
 
-/*
-syntaxErrorExitCode is the exit code that the parser will return if it encounters a
-syntax error while parsing the input. This also ends up being the signal of whether a given
-input is JavaScript or not - without an external tool that detects file types, it's hard
-to tell between 'JavaScript with a few errors' and 'a totally non-JavaScript file'.
-*/
-const syntaxErrorExitCode = 33
+// fatalSyntaxErrorMarker is used by the parser to signal that it is unable to
+// parse a file completely due to syntax errors that cannot be recovered from.
+const fatalSyntaxErrorMarker = "FATAL SYNTAX ERROR"
 
 /*
 runParser handles calling the parser program and provide the specified Javascript source to it,
 either by filename (jsFilePath) or piping jsSource to the program's stdin.
 If sourcePath is empty, sourceString will be parsed as JS code
 */
-func runParser(parserPath, jsFilePath, jsSource string) (string, error) {
+func runParser(parserPath, jsFilePath, jsSource string, extraArgs ...string) (string, error) {
 	nodeArgs := []string{parserPath}
 	if len(jsFilePath) > 0 {
 		nodeArgs = append(nodeArgs, jsFilePath)
+	}
+	if len(extraArgs) > 0 {
+		nodeArgs = append(nodeArgs, extraArgs...)
 	}
 
 	cmd := exec.Command("node", nodeArgs...)
@@ -71,33 +75,34 @@ If sourcePath is empty, sourceString will be parsed as JS code.
 
 parserConfig specifies options relevant to the parser itself, and is produced by InitParser
 
-If the input contains a syntax error (which could mean it's not actually JavaScript),
-then a pointer to parsing.InvalidInput is returned.
+If internal errors occurred during parsing, then a nil parseOutput pointer is returned.
+The other two return values are the raw parser output and the error object respectively.
+Otherwise, the first return value points to the results of parsing while the second
+contains the raw JSON output from the parser.
 */
-func parseJS(parserConfig ParserConfig, filePath string, sourceString string) (result parserOutput, parserOutput string, err error) {
-	parserOutput, err = runParser(parserConfig.ParserPath, filePath, sourceString)
+func parseJS(parserConfig ParserConfig, filePath string, sourceString string) (*parseOutput, string, error) {
+	parserOutput, err := runParser(parserConfig.ParserPath, filePath, sourceString)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == syntaxErrorExitCode {
-				return InvalidInput, "", nil
-			}
 			parserOutput = string(exitErr.Stderr)
 		}
-		return
+		return nil, parserOutput, err
 	}
 
 	// parse JSON to get results as Go struct
 	decoder := json.NewDecoder(strings.NewReader(parserOutput))
-	var storage []parserOutputElement
-	err = decoder.Decode(&storage)
+	var parserData parseDataJSON
+	err = decoder.Decode(&parserData)
 	if err != nil {
-		return
+		return nil, parserOutput, err
 	}
 
-	result.ValidInput = true
+	result := &parseOutput{
+		ValidInput: true,
+	}
 
 	// convert the elements into more natural data structure
-	for _, element := range storage {
+	for _, element := range parserData.Symbols {
 		switch element.SymbolType {
 		case Identifier:
 			symbolSubtype := token.CheckIdentifierType(element.SymbolSubtype)
@@ -135,15 +140,29 @@ func parseJS(parserConfig ParserConfig, filePath string, sourceString string) (r
 				Data: element.Data.(string),
 				Pos:  element.Pos,
 			})
-		case Info:
-			fallthrough
-		case Error:
-			// ignore for now
 		default:
 			log.Warn(fmt.Sprintf("parseJS: unrecognised symbol type %s", element.SymbolType))
 		}
 	}
-	return
+	for _, element := range parserData.Status {
+		status := parserStatus{
+			Type:    string(element.SymbolType),
+			Name:    element.SymbolSubtype,
+			Message: element.Data.(string),
+			Pos:     element.Pos,
+		}
+		switch element.SymbolType {
+		case Info:
+			result.Info = append(result.Info, status)
+		case Error:
+			result.Errors = append(result.Errors, status)
+			if strings.Contains(status.Message, fatalSyntaxErrorMarker) {
+				result.ValidInput = false
+			}
+		}
+	}
+
+	return result, parserOutput, nil
 }
 
 func RunExampleParsing(config ParserConfig, jsFilePath string, jsSourceString string) {
@@ -158,24 +177,7 @@ func RunExampleParsing(config ParserConfig, jsFilePath string, jsSourceString st
 			fmt.Println(string(ee.Stderr))
 		}
 		return
-	} else {
-		fmt.Println("Completed without errors")
-	}
-	println()
-	println("== Parsed Identifiers ==")
-	for _, identifier := range parseResult.Identifiers {
-		fmt.Printf("%v\n", identifier)
-	}
-	println()
-	println("== Parsed Literals ==")
-	for _, literal := range parseResult.Literals {
-		fmt.Printf("%v\n", literal)
 	}
 
-	println()
-	println("== Parsed Comments ==")
-	for _, comment := range parseResult.Comments {
-		fmt.Printf("%v\n", comment)
-	}
-
+	fmt.Printf("%s\n", parseResult.String())
 }

--- a/internal/staticanalysis/parsing/parsing_types.go
+++ b/internal/staticanalysis/parsing/parsing_types.go
@@ -11,18 +11,8 @@ import (
 // Language represents a programming language used for parsing
 type Language string
 
-// SymbolType denotes a type of information collected during parsing.
-// It may be a source code token (see token package), or status about the parsing process (info or error)
-type SymbolType string
-
 const (
 	JavaScript Language = "JavaScript"
-
-	Identifier SymbolType = "Identifier" // source code identifier (variable, class, function name)
-	Literal    SymbolType = "Literal"    // source code data (string, integer, floating point literals)
-	Comment    SymbolType = "Comment"    // source code comments
-	Info       SymbolType = "Info"       // information about the parsing (e.g. number of bytes read by parser)
-	Error      SymbolType = "Error"      // any error encountered by parser; some are recoverable and some are not
 )
 
 var allLanguages = []Language{JavaScript}
@@ -30,6 +20,20 @@ var allLanguages = []Language{JavaScript}
 func SupportedLanguages() []Language {
 	return allLanguages[:]
 }
+
+// tokenType denotes types of source code tokens collected during parsing (see token package)
+type tokenType string
+
+// statusType denotes a type of status reported by the parser about the parsing process
+type statusType string
+
+const (
+	identifier tokenType  = "Identifier" // source code identifier (variable, class, function name)
+	literal    tokenType  = "Literal"    // source code data (string, integer, floating point literals)
+	comment    tokenType  = "Comment"    // source code comments
+	parseInfo  statusType = "Info"       // information about the parsing (e.g. number of bytes read by parser)
+	parseError statusType = "Error"      // any error encountered by parser; some are recoverable and some are not
+)
 
 type parsedIdentifier struct {
 	Type token.IdentifierType
@@ -69,7 +73,7 @@ func (c parsedComment) String() string {
 }
 
 type parserStatus struct {
-	Type    string
+	Type    statusType
 	Name    string
 	Message string
 	Pos     token.Position

--- a/internal/staticanalysis/parsing/parsing_types.go
+++ b/internal/staticanalysis/parsing/parsing_types.go
@@ -2,8 +2,10 @@ package parsing
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
+	"github.com/ossf/package-analysis/internal/utils"
 )
 
 // Language represents a programming language used for parsing
@@ -62,12 +64,50 @@ type parsedComment struct {
 	Pos  token.Position
 }
 
-// parserOutput holds intermediate data from language-specific parsing functions
-type parserOutput struct {
+func (c parsedComment) String() string {
+	return fmt.Sprintf("%s %s pos %d:%d", c.Type, c.Data, c.Pos.Row(), c.Pos.Col())
+}
+
+type parserStatus struct {
+	Type    string
+	Name    string
+	Message string
+	Pos     token.Position
+}
+
+func (s parserStatus) String() string {
+	return fmt.Sprintf("[%s] %s: %s pos %d:%d", s.Type, s.Name, s.Message, s.Pos.Row(), s.Pos.Col())
+}
+
+// parseOutput holds intermediate data from language-specific parsing functions
+type parseOutput struct {
 	ValidInput  bool
 	Identifiers []parsedIdentifier
 	Literals    []parsedLiteral[any]
 	Comments    []parsedComment
+	Info        []parserStatus
+	Errors      []parserStatus
 }
 
-var InvalidInput = parserOutput{ValidInput: false}
+func (p parseOutput) String() string {
+	identifiers := utils.Transform(p.Identifiers, func(pi parsedIdentifier) string { return pi.String() })
+	literals := utils.Transform(p.Literals, func(pl parsedLiteral[any]) string { return pl.String() })
+	comments := utils.Transform(p.Comments, func(c parsedComment) string { return c.String() })
+	info := utils.Transform(p.Info, func(i parserStatus) string { return i.String() })
+	errors := utils.Transform(p.Errors, func(e parserStatus) string { return e.String() })
+
+	parts := []string{
+		"== Identifiers ==",
+		strings.Join(identifiers, "\n"),
+		"== Literals ==",
+		strings.Join(literals, "\n"),
+		"== Comments ==",
+		strings.Join(comments, "\n"),
+		"== Info ==",
+		strings.Join(info, "\n"),
+		"== Errors ==",
+		strings.Join(errors, "\n"),
+	}
+
+	return strings.Join(parts, "\n")
+}


### PR DESCRIPTION
This PR does two main things: restructure the JS parser script with a view to implementing multi-file batch parsing, and improve passing of parse info and errors back to using JSON. 

Summary of changes:
1. use a proper data structure for storing parsing results rather than a global list of strings
2. move all code for parsing a single file into a function (that isn't the `main` function)
3. stop signalling syntax errors using the parser return code; instead output an Error object with a recognisable token
4. separate the output JSON data into two dicts: `tokens` which contains parsed tokens and `status` which contains info and errors  
5. add errors and info from parser output into the Go `parseOutput` struct
6. rename overloaded usages of `Symbol` in the parsing package

Signed-off-by: Max Fisher <maxfisher@google.com>