### PR TITLE
minor static analysis code cleanup

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -121,7 +121,7 @@ func staticAnalysis(pkg *pkgecosystem.Pkg) {
 
 	sbOpts := makeSandboxOptions(analysis.Static)
 
-	results, status, err := worker.RunStaticAnalyses(pkg, sbOpts, staticanalysis.AllTasks())
+	results, status, err := worker.RunStaticAnalysis(pkg, sbOpts, staticanalysis.All)
 	if err != nil {
 		log.Fatal("Static analysis aborted", "error", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -176,7 +176,7 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 
 	var staticResults result.StaticAnalysisResults
 	if resultsBuckets.staticAnalysis != "" {
-		staticResults, _, err = worker.RunStaticAnalyses(pkg, staticSandboxOpts, staticanalysis.AllTasks())
+		staticResults, _, err = worker.RunStaticAnalysis(pkg, staticSandboxOpts, staticanalysis.All)
 		if err != nil {
 			return err
 		}

--- a/internal/staticanalysis/obfuscation/file_signals_test.go
+++ b/internal/staticanalysis/obfuscation/file_signals_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 type fileSignalsTestCase struct {
-	name     string
-	fileData parsing.SingleResult
+	name      string
+	parseData parsing.SingleResult
 }
 
 var fileSignalsTestCases = []fileSignalsTestCase{
 	{
 		name: "simple 1",
-		fileData: parsing.SingleResult{
+		parseData: parsing.SingleResult{
 			Identifiers: []token.Identifier{
 				{Name: "a", Type: token.Variable},
 			},
@@ -34,7 +34,7 @@ var fileSignalsTestCases = []fileSignalsTestCase{
 	},
 	{
 		name: "simple 2",
-		fileData: parsing.SingleResult{
+		parseData: parsing.SingleResult{
 			Identifiers: []token.Identifier{
 				{Name: "test", Type: token.Function},
 				{Name: "a", Type: token.Parameter},
@@ -111,8 +111,8 @@ func init() {
 func TestComputeSignals(t *testing.T) {
 	for _, test := range fileSignalsTestCases {
 		t.Run(test.name, func(t *testing.T) {
-			signals := ComputeFileSignals(test.fileData)
-			testSignals(t, signals, test.fileData.StringLiterals, test.fileData.Identifiers)
+			signals := ComputeFileSignals(test.parseData)
+			testSignals(t, signals, test.parseData.StringLiterals, test.parseData.Identifiers)
 		})
 	}
 }

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -15,22 +15,24 @@ import (
 	"github.com/ossf/package-analysis/pkg/result"
 )
 
+// staticAnalysisImage is the Docker image for the static analysis sandbox
 const staticAnalysisImage = "gcr.io/ossf-malware-analysis/static-analysis"
+
+// staticAnalyzeBinary is the absolute path to the compiled staticanalyze.go binary
+// inside the static analysis sandbox (see sandboxes/staticanalysis/Dockerfile)
 const staticAnalyzeBinary = "/usr/local/bin/staticanalyze"
+
+// resultsJSONFile is the absolute path to the shared mount inside the static analysis sandbox
+// where the output results JSON data should be written
 const resultsJSONFile = "/results.json"
 
 /*
-RunStaticAnalyses performs sandboxed static analysis on the given package.
-Use sbOpts to customise sandbox behaviour.
-If len(tasks) > 0, only the specified static analysis tasks will be performed.
-Otherwise, all available tasks [staticanalysis.AllTasks()] will be performed.
+RunStaticAnalysis performs the given static analysis tasks on package code,
+in a sandboxed environment. To run all available static analyses, pass
+staticanalysis.All as tasks. Use sbOpts to customise sandbox behaviour.
 */
-func RunStaticAnalyses(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks []staticanalysis.Task) (result.StaticAnalysisResults, analysis.Status, error) {
-	if len(tasks) == 0 {
-		tasks = staticanalysis.AllTasks()
-	}
-
-	log.Info("Running static analysis tasks", "tasks", tasks)
+func RunStaticAnalysis(pkg *pkgecosystem.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (result.StaticAnalysisResults, analysis.Status, error) {
+	log.Info("Running static analysis", "tasks", tasks)
 
 	startTime := time.Now()
 


### PR DESCRIPTION
- pass `staticanalysis.All` to RunStaticAnalysis() (renamed from `RunStaticAnalyses()`)
- improve some naming and comments under the static analysis package

Signed-off-by: Max Fisher <maxfisher@google.com>