### PR TITLE
Add function to parse analysis complete notification JSON

### DIFF
--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -1,6 +1,10 @@
 package notification
 
 import (
+	"encoding/json"
+	"fmt"
+	"gocloud.dev/pubsub"
+
 	"github.com/ossf/package-analysis/pkg/pkgidentifier"
 )
 
@@ -8,4 +12,13 @@ import (
 // package analysis completion.
 type AnalysisCompletion struct {
 	Package	pkgidentifier.PkgIdentifier
+}
+
+// ParseJSON takes in a notification JSON and returns an AnalysisCompletion struct.  
+func ParseJSON(msg *pubsub.Message) (AnalysisCompletion, error) {
+	notification := AnalysisCompletion{}
+	if err := json.Unmarshal(msg.Body, &notification); err != nil {
+		return notification, fmt.Errorf("error unmarshalling json: %w", err)
+	}
+	return notification, nil
 }


### PR DESCRIPTION
This function makes it easier for downstream consumers (like package analysis) to parse the package analysis complete notification and identify the package being analysed.

Signed-off-by: Ada Luong <adaluong@google.com>