### PR TITLE
make cloudbuild use Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ endif
 
 
 #
-# This recipe builds images for production. Note: RELEASE_TAG must be set
+# This recipe builds and pushes images for production. Note: RELEASE_TAG must be set
 #
 .PHONY: cloudbuild
-cloudbuild: docker_build_all docker_push_all
+cloudbuild: docker_push_all
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,12 @@ endif
 # This recipe builds and pushes images for production. Note: RELEASE_TAG must be set
 #
 .PHONY: cloudbuild
-cloudbuild: docker_push_all
+cloudbuild: require_release_tag docker_push_all
+
+require_release_tag:
+ifndef RELEASE_TAG
+	$(error RELEASE_TAG must be set)
+endif
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,13 @@ else
 	BUILD_ARG=--build-arg=SANDBOX_IMAGE_TAG=$(TAG)
 endif
 
-.PHONY: all
-all: docker_build_all
+
+#
+# This recipe builds images for production. Note: RELEASE_TAG must be set
+#
+.PHONY: cloudbuild
+cloudbuild: docker_build_all docker_push_all
+
 
 #
 # These recipes build all the top-level docker images

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ endif
 .PHONY: cloudbuild
 cloudbuild: require_release_tag docker_push_all
 
+.PHONY: require_release_tag
 require_release_tag:
 ifndef RELEASE_TAG
 	$(error RELEASE_TAG must be set)

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -2,8 +2,6 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   env:
   - 'RELEASE_TAG=$TAG_NAME'
-  - 'PUSH=true'
   entrypoint: bash
-  dir: build
-  args: ['-ex', 'build_docker.sh']
+  args: ['-ex', 'make', 'cloudbuild']
 timeout: 1200s

--- a/scripts/run_analysis.sh
+++ b/scripts/run_analysis.sh
@@ -113,7 +113,7 @@ if [[ $# -eq 0 ]]; then
 	HELP=1
 fi
 
-DOCKER_OPTS=("run" "--cgroupns=host" "--privileged")
+DOCKER_OPTS=("run" "--cgroupns=host" "--privileged" "--rm")
 
 DOCKER_MOUNTS=("-v" "/var/lib/containers:/var/lib/containers" "-v" "$RESULTS_DIR:/results" "-v" "$STATIC_RESULTS_DIR:/staticResults" "-v" "$FILE_WRITE_RESULTS_DIR:/writeResults" "-v" "$LOGS_DIR:/tmp")
 


### PR DESCRIPTION
Switch from the old `build_docker.sh` script to the Makefile for production builds. Fixes #612.

Signed-off-by: Max Fisher <maxfisher@google.com>