### PR TITLE
Make docker-compose more reliable.

### DIFF
--- a/configs/e2e/docker-compose.yml
+++ b/configs/e2e/docker-compose.yml
@@ -3,7 +3,13 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper@sha256:87314e87320abf190f0407bf1689f4827661fbb4d671a41cba62673b45b66bfa
     ports:
-      - "2181:2181"
+      - 2181:2181
+    healthcheck:
+      test: nc -z localhost 2181 || exit -1
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: on-failure
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -14,7 +20,14 @@ services:
     ports:
       - 9094:9094
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: kafka-topics --bootstrap-server kafka:9092 --list
+      interval: 30s
+      timeout: 10s
+      retries: 23
+    restart: on-failure
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_LISTENERS: INTERNAL://kafka:9092,OUTSIDE://kafka:9094
@@ -28,6 +41,7 @@ services:
     hostname: minio
     ports:
       - 9000:9000
+    restart: on-failure
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
@@ -43,6 +57,7 @@ services:
   analysis:
     image: gcr.io/ossf-malware-analysis/analysis:latest
     privileged: true
+    restart: unless-stopped
     entrypoint: "/usr/local/bin/worker"
     environment:
       OSSMALWARE_WORKER_SUBSCRIPTION: kafka://worker?topic=workers
@@ -55,25 +70,31 @@ services:
       AWS_SECRET_ACCESS_KEY: minio123
       AWS_REGION: dummy_region
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
 
   scheduler:
     image: gcr.io/ossf-malware-analysis/scheduler:latest
     entrypoint: "/usr/local/bin/scheduler"
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
+    restart: on-failure
     environment:
       OSSMALWARE_WORKER_TOPIC: kafka://workers
       OSSMALWARE_SUBSCRIPTION_URL: kafka://worker?topic=package-feeds
       KAFKA_BROKERS: kafka:9092
 
   feeds:
-    restart: "on-failure"
     image: gcr.io/ossf-malware-analysis/scheduled-feeds:latest
+    restart: on-failure
     ports:
       - 8080:8080
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     environment:
       PACKAGE_FEEDS_CONFIG_PATH: /config/feeds.yml
     volumes:


### PR DESCRIPTION
1. Add health checks to kafka and zookeeper
2. Use long-form depends_on to ensure dependents are only started when dependencies are health
3. Specify restart policies to keep failed services running