### PR TITLE
Enable pprof for debugging inside docker-compose.

### DIFF
--- a/configs/e2e/docker-compose.yml
+++ b/configs/e2e/docker-compose.yml
@@ -57,6 +57,8 @@ services:
   analysis:
     image: gcr.io/ossf-malware-analysis/analysis:latest
     privileged: true
+    ports:
+      - 6060:6060
     restart: unless-stopped
     entrypoint: "/usr/local/bin/worker"
     environment:
@@ -65,6 +67,7 @@ services:
       OSSF_MALWARE_ANALYSIS_RESULTS: s3://package-analysis?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       OSSF_MALWARE_STATIC_ANALYSIS_RESULTS: s3://package-analysis-static?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS: s3://package-analysis-file-writes?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
+      OSSF_MALWARE_ANALYSIS_ENABLE_PROFILER: "true"
       KAFKA_BROKERS: kafka:9092
       AWS_ACCESS_KEY_ID: minio
       AWS_SECRET_ACCESS_KEY: minio123


### PR DESCRIPTION
This change make it possible to visit http://localhost:6060/debug/pprof/ while docker-compose is running and view the pprof server running in the Analysis worker binary.

Debugging is now much easier as the state of the running process can be extracted via a website.