### PR TITLE
replace println with fmt.Println

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -47,11 +48,11 @@ func parseBucketPath(path string) (string, string) {
 }
 
 func printAnalysisModes() {
-	println("Available analysis modes:")
+	fmt.Println("Available analysis modes:")
 	for _, mode := range analysis.AllModes() {
-		println(mode)
+		fmt.Println(mode)
 	}
-	println()
+	fmt.Println()
 }
 
 // makeSandboxOptions prepares options for the sandbox based on command line arguments.

--- a/internal/staticanalysis/parsing/js_parsing.go
+++ b/internal/staticanalysis/parsing/js_parsing.go
@@ -206,7 +206,7 @@ func parseJS(parserConfig ParserConfig, input externalcmd.Input) (languageResult
 func RunExampleParsing(config ParserConfig, input externalcmd.Input) {
 	parseResult, rawOutput, err := parseJS(config, input)
 
-	println("\nRaw JSON:\n", rawOutput)
+	fmt.Println("\nRaw JSON:\n", rawOutput)
 
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)

--- a/internal/staticanalysis/parsing/js_parsing_test.go
+++ b/internal/staticanalysis/parsing/js_parsing_test.go
@@ -1,6 +1,7 @@
 package parsing
 
 import (
+	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -392,7 +393,7 @@ func TestParseJS(t *testing.T) {
 			got := result["stdin"]
 			if err != nil {
 				t.Errorf("parseJS() error = %v", err)
-				println("Parser output:\n", rawOutput)
+				fmt.Println("Parser output:\n", rawOutput)
 				return
 			}
 			if len(tt.want.Literals) != len(got.Literals) {
@@ -437,7 +438,7 @@ func TestParseJS(t *testing.T) {
 			}
 
 			if t.Failed() || printAllJSON {
-				println("Raw JSON:\n", rawOutput)
+				fmt.Println("Raw JSON:\n", rawOutput)
 			}
 		})
 	}


### PR DESCRIPTION
According to https://go.dev/ref/spec#Bootstrapping, `println` should not be relied upon to stay in the language. This PR changes usages of `println` to `fmt.Println` which is part of the standard library.  