### PR TITLE
remove duplicated default text for combined sandbox option

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -29,7 +29,7 @@ var (
 	staticUpload        = flag.String("upload-static", "", "bucket path for uploading static analysis results")
 	uploadFileWriteInfo = flag.String("upload-file-write-info", "", "bucket path for uploading information from file writes")
 	offline             = flag.Bool("offline", false, "disables sandbox network access")
-	combinedSandbox     = flag.Bool("combined-sandbox", true, "use combined sandbox image for dynamic analysis (default true)")
+	combinedSandbox     = flag.Bool("combined-sandbox", true, "use combined sandbox image for dynamic analysis")
 	listModes           = flag.Bool("list-modes", false, "prints out a list of available analysis modes")
 	help                = flag.Bool("help", false, "print help on available options")
 	analysisMode        = utils.CommaSeparatedFlags("mode", "dynamic",


### PR DESCRIPTION
The inbuilt help printing function already includes the default value for flag options, so adding it manually results in  duplicated "(default true)" text being output