### PR TITLE
Run static analysis locally by default

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -33,7 +33,7 @@ var (
 	combinedSandbox     = flag.Bool("combined-sandbox", true, "use combined sandbox image for dynamic analysis")
 	listModes           = flag.Bool("list-modes", false, "prints out a list of available analysis modes")
 	help                = flag.Bool("help", false, "print help on available options")
-	analysisMode        = utils.CommaSeparatedFlags("mode", "dynamic",
+	analysisMode        = utils.CommaSeparatedFlags("mode", "static,dynamic",
 		"list of analysis modes to run, separated by commas. Use -list-modes to see available options")
 )
 

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -33,7 +33,7 @@ var (
 	combinedSandbox     = flag.Bool("combined-sandbox", true, "use combined sandbox image for dynamic analysis")
 	listModes           = flag.Bool("list-modes", false, "prints out a list of available analysis modes")
 	help                = flag.Bool("help", false, "print help on available options")
-	analysisMode        = utils.CommaSeparatedFlags("mode", "static,dynamic",
+	analysisMode        = utils.CommaSeparatedFlags("mode", []string{"static", "dynamic"},
 		"list of analysis modes to run, separated by commas. Use -list-modes to see available options")
 )
 

--- a/internal/utils/comma_separated_flags.go
+++ b/internal/utils/comma_separated_flags.go
@@ -9,10 +9,10 @@ import (
 // to allow passing a comma-separated list of strings as a single command-line argument.
 //
 // Make sure to call InitFlag() on the returned struct before calling flag.Parse().
-func CommaSeparatedFlags(name, value, usage string) CommaSeparatedFlagsData {
+func CommaSeparatedFlags(name string, values []string, usage string) CommaSeparatedFlagsData {
 	return CommaSeparatedFlagsData{
 		Name:   name,
-		Values: []string{value},
+		Values: values,
 		Info:   usage,
 	}
 }

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -24,7 +24,7 @@ var (
 	localFile   = flag.String("local", "", "local package archive containing package to be analysed. Name must match -package argument")
 	output      = flag.String("output", "", "where to write output JSON results (default stdout)")
 	help        = flag.Bool("help", false, "prints this help and list of available analyses")
-	analyses    = utils.CommaSeparatedFlags("analyses", "all", "comma-separated list of static analysis tasks to perform")
+	analyses    = utils.CommaSeparatedFlags("analyses", []string{"all"}, "comma-separated list of static analysis tasks to perform")
 )
 
 type workDirs struct {


### PR DESCRIPTION
This PR enables static analysis by default when run locally from the analysis image. It also required modifying the `utils.CommaSeparatedFlags()` function to allow multiple initial values for the flag.