### PR TITLE
Prepare to move away from global logger + fix race condition in Writer

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -17,6 +17,8 @@ import (
 )
 
 // Level represents a specific logging level. It wraps zapcore.Level.
+//
+// Deprecated: use zapcore.Level directly.
 type Level zapcore.Level
 
 const (
@@ -54,7 +56,7 @@ var (
 // "false" will use the default development configuration.
 //
 // Note: this method MUST be called before any other method in this package.
-func Initialize(env string) {
+func Initialize(env string) *zap.Logger {
 	var err error
 	var logger *zap.Logger
 	switch strings.ToLower(env) {
@@ -75,7 +77,9 @@ func Initialize(env string) {
 		golog.Panic(err)
 	}
 	zap.RedirectStdLog(logger)
-	defaultLogger = logger.WithOptions(zap.AddCallerSkip(1)).Sugar()
+	logger = logger.WithOptions(zap.AddCallerSkip(1))
+	defaultLogger = logger.Sugar() // Set defaultLogger to provide legacy support
+	return logger
 }
 
 func checkInit() {
@@ -86,6 +90,8 @@ func checkInit() {
 
 // Debug is a convenience wrapper for calling Debugw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Debug directly.
 func Debug(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Debugw(msg, keysAndValues...)
@@ -93,6 +99,8 @@ func Debug(msg string, keysAndValues ...interface{}) {
 
 // Info is a convenience wrapper for calling Infow on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Info directly.
 func Info(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Infow(msg, keysAndValues...)
@@ -100,6 +108,8 @@ func Info(msg string, keysAndValues ...interface{}) {
 
 // Warn is a convenience wrapper for calling Warnw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Warn directly.
 func Warn(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Warnw(msg, keysAndValues...)
@@ -107,6 +117,8 @@ func Warn(msg string, keysAndValues ...interface{}) {
 
 // Error is a convenience wrapper for calling Errorw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Error directly.
 func Error(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Errorw(msg, keysAndValues...)
@@ -114,6 +126,8 @@ func Error(msg string, keysAndValues ...interface{}) {
 
 // Fatal is a convenience wrapper for calling Fatalw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Fatal directly.
 func Fatal(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Fatalw(msg, keysAndValues...)
@@ -121,6 +135,8 @@ func Fatal(msg string, keysAndValues ...interface{}) {
 
 // Panic is a convenience wrapper for calling Panicw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call Panic directly.
 func Panic(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.Panicw(msg, keysAndValues...)
@@ -128,6 +144,8 @@ func Panic(msg string, keysAndValues ...interface{}) {
 
 // DPanic is a convenience wrapper for calling DPanicw on the default
 // zap.SugaredLogger instance.
+//
+// Deprecated: Use a *zap.Logger instance and call DPanic directly.
 func DPanic(msg string, keysAndValues ...interface{}) {
 	checkInit()
 	defaultLogger.DPanicw(msg, keysAndValues...)

--- a/internal/log/writer.go
+++ b/internal/log/writer.go
@@ -1,72 +1,90 @@
 package log
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 	"unicode"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-func logLine(logger *zap.SugaredLogger, level Level, l string) {
-	switch level {
-	case DebugLevel:
-		logger.Debug(l)
-	case InfoLevel:
-		logger.Info(l)
-	case WarnLevel:
-		logger.Warn(l)
-	case ErrorLevel:
-		logger.Error(l)
-	case DPanicLevel:
-		logger.DPanic(l)
-	case PanicLevel:
-		logger.Panic(l)
-	case FatalLevel:
-		logger.Fatal(l)
-	}
-}
-
-// Writer returns an io.WriteCloser that logs each line written as a single log
-// entry at the given level with the supplied keysAndValues.
+// Writer returns an io.WriteCloser that logs each line written as a single
+// log entry at the given level with the supplied keysAndValues.
 //
-// Close() must be called to free up the resources used.
+// Close() must be called to free up the resources used and flush any unwritten
+// log entries to the logger.
+//
+// Deprecated: use NewWriter with zap.Logger and zapcore.Level directly.
 func Writer(level Level, keysAndValues ...interface{}) io.WriteCloser {
 	checkInit()
-
-	r, w := io.Pipe()
-	go func() {
-		err := WriteTo(level, r, keysAndValues...)
-		r.Close()
-		if err != nil {
-			Error("Writer failed.",
-				"error", err)
-		}
-	}()
-	return w
+	logger := defaultLogger.With(keysAndValues...).Desugar()
+	return NewWriter(logger, zapcore.Level(level))
 }
 
-// WriteTo will log each line read from r as a single log entry at the given
-// level with the supplied keysAndValues.
+// NewWriter returns an io.WriteCloser that logs each line written as a single
+// log entry at the given level with the supplied keysAndValues.
 //
-// This method will block until r returns an EOF or causes an error.
-func WriteTo(level Level, rd io.Reader, keysAndValues ...interface{}) error {
-	logger := defaultLogger.With(keysAndValues...)
-	r := bufio.NewReader(rd)
-	for {
-		line, err := r.ReadBytes('\n')
-		// Trim any trailing space
-		line = bytes.TrimRightFunc(line, unicode.IsSpace)
-		// Swallow empty lines
-		if len(line) > 0 {
-			logLine(logger, level, string(line))
-		}
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
+// Close() must be called to free up the resources used and flush any unwritten
+// log entries to the logger.
+func NewWriter(logger *zap.Logger, level zapcore.Level) io.WriteCloser {
+	return &writer{
+		logger: logger,
+		level:  level,
 	}
+}
+
+type writer struct {
+	logger *zap.Logger
+	level  zapcore.Level
+	buffer bytes.Buffer
+}
+
+// Write implements the io.Writer interface.
+//
+// Each line of bytes written appears as a log entry.
+func (w *writer) Write(p []byte) (int, error) {
+	written := 0
+	for {
+		if len(p) == 0 {
+			// p is now empty, so exit with the bytes written
+			return written, nil
+		}
+		i := bytes.IndexByte(p, '\n')
+		if i == -1 {
+			// No more newlines to consume, so save the buffer and return
+			n, err := w.buffer.Write(p)
+			return written + n, err
+		}
+		// Append to the buffer.
+		n, err := w.buffer.Write(p[:i])
+		written += n
+		if err != nil {
+			return written, err
+		}
+		// Update the input and consume the newline
+		p = p[i+1:]
+		written += 1
+		// Dump the buffer to the log
+		line := w.buffer.Bytes()
+		// Trim any trailing space - this won't include the newline
+		line = bytes.TrimRightFunc(line, unicode.IsSpace)
+		// Swallow any empty lines
+		if len(line) > 0 {
+			w.logger.Log(w.level, string(line))
+		}
+		// Reset the buffer.
+		w.buffer.Reset()
+	}
+}
+
+// Close implements the io.Closer interface.
+//
+// Any unwritten bytes written as a final log entry.
+func (w *writer) Close() error {
+	if w.buffer.Len() > 0 {
+		w.logger.Log(w.level, w.buffer.String())
+		w.buffer.Reset()
+	}
+	return nil
 }

--- a/internal/log/writer_test.go
+++ b/internal/log/writer_test.go
@@ -1,0 +1,196 @@
+package log_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/exp/slices"
+
+	"github.com/ossf/package-analysis/internal/log"
+)
+
+func initLogs(t *testing.T, l zapcore.Level) (*zap.Logger, *observer.ObservedLogs) {
+	t.Helper()
+	core, obs := observer.New(l)
+	return zap.New(core), obs
+}
+
+func TestNewWriter_SingleLine(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	want := "this is the log message"
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(want)))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+	if got := obs.Len(); got != 1 {
+		t.Fatalf("Got %d log entries; want 1", got)
+	}
+	entry := obs.All()[0]
+	if got := entry.Message; got != want {
+		t.Errorf("Got %v entry; want %v", got, want)
+	}
+}
+
+func TestNewWriter_MultiLine(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	want := []string{
+		"one",
+		"two",
+		"three",
+		"four",
+	}
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(strings.Join(want, "\n"))))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+
+	var got []string
+	for _, entry := range obs.All() {
+		got = append(got, entry.Message)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("Got log entries = %v; want %v", got, want)
+	}
+}
+
+func TestNewWriter_LevelSuppress(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.WarnLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	want := "this is the log message"
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(want)))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+	if got := obs.Len(); got != 0 {
+		t.Fatalf("Got %d log entries; want none", got)
+	}
+}
+
+func TestNewWriter_MultiWithEmptyLine(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	in := []string{"one", "two", "", "four"}
+	want := []string{"one", "two", "four"}
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(strings.Join(in, "\n"))))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+
+	var got []string
+	for _, entry := range obs.All() {
+		got = append(got, entry.Message)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("Got log entries = %v; want %v", got, want)
+	}
+}
+
+func TestNewWriter_MultiWithTrailingSpaces(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	in := []string{"one    ", "two \t \f \v \r", "\t\t\t\t", "four"}
+	want := []string{"one", "two", "four"}
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(strings.Join(in, "\n"))))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+
+	var got []string
+	for _, entry := range obs.All() {
+		got = append(got, entry.Message)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("Got log entries = %v; want %v", got, want)
+	}
+}
+
+func TestNewWriter_Empty(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	_, err := io.Copy(w, &bytes.Buffer{})
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+	if got := obs.Len(); got != 0 {
+		t.Fatalf("Got %d log entries; want none", got)
+	}
+}
+
+func TestNewWriter_TrailingNewline(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	want := "this is the log message"
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(want+"\n")))
+	w.Close()
+
+	if err != nil {
+		t.Fatalf("Writing failed: %v", err)
+	}
+	if got := obs.Len(); got != 1 {
+		t.Fatalf("Got %d log entries; want 1", got)
+	}
+	entry := obs.All()[0]
+	if got := entry.Message; got != want {
+		t.Errorf("Got %v entry; want %v", got, want)
+	}
+}
+
+func TestNewWriter_MultiWrites(t *testing.T) {
+	logger, obs := initLogs(t, zapcore.DebugLevel)
+	w := log.NewWriter(logger, zapcore.InfoLevel)
+
+	in1 := []string{"one", "two", "", "fourty "}
+	in2 := []string{"two", "...", "done"}
+	want := []string{"one", "two", "fourty two", "...", "done"}
+
+	_, err := io.Copy(w, bytes.NewBuffer([]byte(strings.Join(in1, "\n"))))
+	if err != nil {
+		t.Fatalf("Writing #1 failed: %v", err)
+	}
+
+	_, err = io.Copy(w, bytes.NewBuffer([]byte(strings.Join(in2, "\n"))))
+	if err != nil {
+		t.Fatalf("Writing #2 failed: %v", err)
+	}
+	w.Close()
+
+	var got []string
+	for _, entry := range obs.All() {
+		got = append(got, entry.Message)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("Got log entries = %v; want %v", got, want)
+	}
+}


### PR DESCRIPTION
`log.Initialize()` now returns `*zap.Logger` that can used for logging instead of the global logger.

This is a step towards solving #185.

In the process of implementing this change I started cleaning up the `Writer` implementation and adding tests - and discovered a race condition.

Basically, writes to the `io.Pipe()` writer may not be read by the reader and written the log before writer is closed and finished.

This is a result of the async goroutine consuming the reader.

The new implementation does not have this issue as writes are synchronously written to the log.