### PR TITLE
Use *zap.Logger in the scheduler, rather than the global log

### DIFF
--- a/cmd/scheduler/proxy/proxy.go
+++ b/cmd/scheduler/proxy/proxy.go
@@ -29,6 +29,7 @@ func (proxy *PubSubProxy) Listen(ctx context.Context, logger *zap.Logger, prepro
 			return err
 		}
 		go func(m *pubsub.Message) {
+			logger := logger.With(zap.String("message_id", m.LoggableID))
 			outMsg, err := preprocess(msg)
 			if err != nil {
 				// Failure to parse and process messages should result in an acknowledgement


### PR DESCRIPTION
For #185.

Uses `*zap.Logger` directly, so we can make use of embedded context fields.