### PR TITLE
Update hashing implementation to reduce memory consumption

### DIFF
--- a/internal/utils/hash_file.go
+++ b/internal/utils/hash_file.go
@@ -3,15 +3,20 @@ package utils
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 )
 
 func HashFile(path string) (string, error) {
-	bytes, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
-
-	hash := sha256.Sum256(bytes)
-	return fmt.Sprintf("sha256:%x", hash), nil
+	defer f.Close()
+	hash := sha256.New()
+	_, err = io.Copy(hash, f)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", hash.Sum([]byte{})), nil
 }

--- a/internal/utils/hash_file_test.go
+++ b/internal/utils/hash_file_test.go
@@ -1,0 +1,65 @@
+package utils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ossf/package-analysis/internal/utils"
+)
+
+func TestHashFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{
+			name:     "empty file",
+			contents: "",
+			want:     "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:     "single line",
+			contents: "Hello, World!",
+			want:     "sha256:dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f",
+		},
+		{
+			name:     "mutli line",
+			contents: "Hello,\nWorld!",
+			want:     "sha256:d62b51d504f02642dab5003959af0c1557094c7d49dcc544aba37a0a5d8d1d0d",
+		},
+		{
+			name:     "trailing new line",
+			contents: "Hello,\nWorld!\n",
+			want:     "sha256:f5651768767f5e83d7001136251b6558a6d01550b04e12c1678ea3a0ca1e8a30",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := filepath.Join(t.TempDir(), "file.txt")
+			err := os.WriteFile(f, []byte(test.contents), 0o666)
+			if err != nil {
+				t.Fatalf("Failed to prepare hash file: %v", err)
+			}
+			got, err := utils.HashFile(f)
+			if err != nil {
+				t.Fatalf("Failed to generate hash: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("HashFile() = %v; want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestHashFile_MissingFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "missing.txt")
+	got, err := utils.HashFile(f)
+	if err == nil {
+		t.Error("HashFile() returned no error; want an error")
+	}
+	if got != "" {
+		t.Errorf("HashFile() = %v; want ''", got)
+	}
+}


### PR DESCRIPTION
Replace the usage of `os.ReadFile` which returns a `[]byte` containing the contents of the file to be hashed.

This is expensive, especially for large files and could potentially cause a denial-of-service if a large enough file is included in a package (in-particular one that zips efficiently so the zip is small, but the file is huge).

Instead, we use the fact that `hash.Hash` implements `io.Writer` to open the file and read it  using `io.Copy` instead. This ensures that memory consumption remains limited to the size of the buffer used inside `io.Copy`.