### PR TITLE
Remove suspicious files field from obfuscation results

### DIFF
--- a/internal/staticanalysis/obfuscation/analyze.go
+++ b/internal/staticanalysis/obfuscation/analyze.go
@@ -6,7 +6,6 @@ import "github.com/ossf/package-analysis/internal/staticanalysis/parsing"
 // obtained from parsing each file in the package.
 func Analyze(fileParseData parsing.PackageResult) Result {
 	result := Result{
-		SuspiciousFiles: []string{},
 		ExcludedFiles:   []string{},
 		Signals:         map[string]FileSignals{},
 	}

--- a/internal/staticanalysis/obfuscation/result.go
+++ b/internal/staticanalysis/obfuscation/result.go
@@ -7,11 +7,6 @@ import (
 
 // Result holds all data produced by obfuscation analysis (see Analyze() in analyze.go).
 type Result struct {
-	// SuspiciousFiles lists all files in the package that are suspected to contain
-	// obfuscated code. This should be treated not as an absolute determination but
-	// more of a flag for human review.
-	SuspiciousFiles []string `json:"suspicious_files"`
-
 	// ExcludedFiles is a list of package files that were excluded from analysis,
 	// e.g. because they could not be parsed by any supported parser.
 	ExcludedFiles []string `json:"excluded_files"`
@@ -29,7 +24,6 @@ func (r Result) String() string {
 	}
 
 	parts := []string{
-		fmt.Sprintf("suspicious files: \n%v", r.SuspiciousFiles),
 		fmt.Sprintf("excluded files:\n%v", r.ExcludedFiles),
 		fmt.Sprintf("file signals\n%s", strings.Join(fileSignalsStrings, "\n\n")),
 	}


### PR DESCRIPTION
This field is currently unpopulated and we probably won't add code to populate it in this project, so we should remove it. 