### PR TITLE
fix incorrect error handling in analysis binary

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -110,7 +110,7 @@ func dynamicAnalysis(pkg *pkgmanager.Pkg) {
 
 	// this is only valid if RunDynamicAnalysis() returns nil err
 	if lastStatus != analysis.StatusCompleted {
-		log.Fatal("Dynamic analysis phase did not complete successfully",
+		log.Warn("Dynamic analysis phase did not complete successfully",
 			"lastRunPhase", lastRunPhase,
 			"status", lastStatus)
 	}


### PR DESCRIPTION
Fixes issue in #683 - incorrect fatal loglevel when dynamic analysis does not finish successfully due to invalid package