### PR TITLE
Simplify the passing of sandbox options around and reduce modality.

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -62,8 +62,8 @@ func printAnalysisModes() {
 //  1. The image tag is always passed through. An empty tag is the same as "latest".
 //  2. A local package is mapped into the sandbox if applicable.
 //  3. Image pulling is disabled if the "-nopull" command-line flag was used.
-func makeSandboxOptions(mode analysis.Mode) []sandbox.Option {
-	sbOpts := worker.DefaultSandboxOptions(mode, *imageTag)
+func makeSandboxOptions() []sandbox.Option {
+	sbOpts := []sandbox.Option{sandbox.Tag(*imageTag)}
 
 	if *localPkg != "" {
 		sbOpts = append(sbOpts, sandbox.Volume(*localPkg, *localPkg))
@@ -83,7 +83,7 @@ func dynamicAnalysis(pkg *pkgmanager.Pkg) {
 		sandbox.InitNetwork()
 	}
 
-	sbOpts := makeSandboxOptions(analysis.Dynamic)
+	sbOpts := append(worker.DynamicSandboxOptions(), makeSandboxOptions()...)
 
 	results, lastRunPhase, lastStatus, err := worker.RunDynamicAnalysis(pkg, sbOpts)
 	if err != nil {
@@ -121,7 +121,7 @@ func staticAnalysis(pkg *pkgmanager.Pkg) {
 		sandbox.InitNetwork()
 	}
 
-	sbOpts := makeSandboxOptions(analysis.Static)
+	sbOpts := append(worker.DynamicSandboxOptions(), makeSandboxOptions()...)
 
 	results, status, err := worker.RunStaticAnalysis(pkg, sbOpts, staticanalysis.All)
 	if err != nil {

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -121,7 +121,7 @@ func staticAnalysis(pkg *pkgmanager.Pkg) {
 		sandbox.InitNetwork()
 	}
 
-	sbOpts := append(worker.DynamicSandboxOptions(), makeSandboxOptions()...)
+	sbOpts := append(worker.StaticSandboxOptions(), makeSandboxOptions()...)
 
 	results, status, err := worker.RunStaticAnalysis(pkg, sbOpts, staticanalysis.All)
 	if err != nil {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,6 @@
+cloud.google.com/go/apigeeregistry v0.4.0/go.mod h1:EUG4PGcsZvxOXAdyEghIdXwAEi/4MEaoqLMLDMIwKXY=
+cloud.google.com/go/apikeys v0.4.0/go.mod h1:XATS/yqZbaBK0HOssf+ALHp8jAlNHUgyfprvNcBIszU=
+cloud.google.com/go/datacatalog v1.8.1/go.mod h1:RJ58z4rMp3gvETA465Vg+ag8BGgBdnRPEMMSTr5Uv+M=
+cloud.google.com/go/dialogflow v1.29.0/go.mod h1:b+2bzMe+k1s9V+F2jbJwpHPzrnIyHihAdRFMtn2WXuM=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+google.golang.org/genproto v0.0.0-20221109142239-94d6d90a7d66/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=

--- a/internal/worker/sandbox_options.go
+++ b/internal/worker/sandbox_options.go
@@ -1,28 +1,27 @@
 package worker
 
 import (
-	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
-// DefaultSandboxOptions initialises sandbox options necessary to run the given analysis mode.
-func DefaultSandboxOptions(mode analysis.Mode, imageTag string) []sandbox.Option {
-	switch mode {
-	case analysis.Dynamic:
-		return []sandbox.Option{
-			sandbox.Tag(imageTag),
-			sandbox.EnableStrace(),
-			sandbox.EnableRawSockets(),
-			sandbox.EnablePacketLogging(),
-			sandbox.LogStdOut(),
-			sandbox.LogStdErr(),
-		}
-	case analysis.Static:
-		return []sandbox.Option{
-			sandbox.Tag(imageTag),
-			sandbox.EchoStdErr(),
-		}
-	default:
-		return []sandbox.Option{}
+// 		sandbox.Tag(imageTag),
+
+// StaticSandboxOptions provides a set of sandbox options necessary to run the
+// static analysis sandboxes.
+func StaticSandboxOptions() []sandbox.Option {
+	return []sandbox.Option{
+		sandbox.EchoStdErr(),
+	}
+}
+
+// DynamicSandboxOptions provides a set of sandbox options necessary to run
+// dynamic analysis sandboxes.
+func DynamicSandboxOptions() []sandbox.Option {
+	return []sandbox.Option{
+		sandbox.EnableStrace(),
+		sandbox.EnableRawSockets(),
+		sandbox.EnablePacketLogging(),
+		sandbox.LogStdOut(),
+		sandbox.LogStdErr(),
 	}
 }

--- a/internal/worker/sandbox_options.go
+++ b/internal/worker/sandbox_options.go
@@ -4,8 +4,6 @@ import (
 	"github.com/ossf/package-analysis/internal/sandbox"
 )
 
-// 		sandbox.Tag(imageTag),
-
 // StaticSandboxOptions provides a set of sandbox options necessary to run the
 // static analysis sandboxes.
 func StaticSandboxOptions() []sandbox.Option {


### PR DESCRIPTION
Split the sandbox option factory function into two - the mode was always a static arg and never a dynamic variable, so it isn't necessary. This allows for a reduction in state.

Additionally the logic to build up the option-specific args is now done prior to merging with the sandbox specific args.

Also updates `go.work.sum`