### PR TITLE
Fix kubectl install that is breaking the docker build.

### DIFF
--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -19,8 +19,8 @@ ENV DEBCONF_NOWARNINGS="yes"
 
 # setup repo for kubectl
 RUN mkdir -m 0700 -p /etc/apt/keyrings && \
- 	curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg -o /etc/apt/keyrings/kubernetes.gpg && \
- 	echo "deb [signed-by=/etc/apt/keyrings/kubernetes.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+	curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg && \
+	echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
 
 # install keys for powershell
 RUN curl -fsSL "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" -o /setup/packages-microsoft-prod.deb && \


### PR DESCRIPTION
Dynamic Sandbox image was failing to create (e.g. https://github.com/ossf/package-analysis/actions/runs/5051225730/jobs/9062834834?pr=723)

This change attempts to fix the issue (based on https://github.com/kubernetes/release/issues/2862)