### PR TITLE
Allow copying files from sandbox to host

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -94,6 +95,12 @@ type Sandbox interface {
 	//
 	// Once called the Sandbox cannot be used again.
 	Clean() error
+
+	// CopyToHost copies a path in the sandbox (src) to a path in the host (dest).
+	// It will fail if the src path does not exist in the sandbox.
+	// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for
+	// semantics of src and dest paths
+	CopyToHost(src, dest string) error
 }
 
 // volume represents a volume mapping between a host src and a container dest.
@@ -109,19 +116,35 @@ func (v volume) args() []string {
 	}
 }
 
-// copy represents a host source and a destination that will be used within the sandbox container.
-type copy struct {
-	src  string
-	dest string
+// copySpec specifies the source and destination of a copy operation.
+// The copy may be made from the host into the sandbox or vice versa.
+// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for
+// semantics of src and dest paths.
+// srcInContainer and destInContainer specify whether the copy source
+// and destination are respectively in the host (false) or container (true)
+type copySpec struct {
+	src             string
+	dest            string
+	srcInContainer  bool
+	destInContainer bool
 }
 
-func (c copy) args(s *podmanSandbox) []string {
-	copyDest := fmt.Sprintf("%s:%s", s.container, c.dest)
-	return []string{
-		"cp",
-		c.src,
-		copyDest,
+func (c copySpec) args(containerId string) []string {
+	copySrc := c.src
+	if c.srcInContainer {
+		copySrc = fmt.Sprintf("%s:%s", containerId, c.src)
 	}
+
+	copyDest := c.dest
+	if c.destInContainer {
+		copyDest = fmt.Sprintf("%s:%s", containerId, c.dest)
+	}
+
+	return []string{"cp", copySrc, copyDest}
+}
+
+func (c copySpec) String() string {
+	return strings.Join(c.args("container"), " ")
 }
 
 // Implements the Sandbox interface using "podman".
@@ -140,7 +163,7 @@ type podmanSandbox struct {
 	echoStdOut bool
 	echoStdErr bool
 	volumes    []volume
-	copies     []copy
+	copies     []copySpec
 }
 
 type (
@@ -231,11 +254,14 @@ func Volume(src, dest string) Option {
 	})
 }
 
+// Copy copies a file from the host into the sandbox during initialisation
 func Copy(src, dest string) Option {
 	return option(func(sb *podmanSandbox) {
-		sb.copies = append(sb.copies, copy{
-			src:  src,
-			dest: dest,
+		sb.copies = append(sb.copies, copySpec{
+			src:             src,
+			dest:            dest,
+			srcInContainer:  false,
+			destInContainer: true,
 		})
 	})
 }
@@ -364,14 +390,6 @@ func (s *podmanSandbox) extraArgs() []string {
 	return args
 }
 
-func (s *podmanSandbox) copyArgs() []string {
-	args := make([]string, 0)
-	for _, c := range s.copies {
-		args = append(args, c.args(s)...)
-	}
-	return args
-}
-
 func (s *podmanSandbox) imageWithTag() string {
 	tag := "latest"
 	if s.tag != "" {
@@ -403,11 +421,17 @@ func (s *podmanSandbox) init() error {
 		return fmt.Errorf("error creating container: %w", err)
 	}
 
-	if args := s.copyArgs(); len(args) > 0 {
-		if err := podmanRun(args...); err != nil {
-			return fmt.Errorf("failed copying arguments into sandbox: %w", err)
+	// run each copy command separately
+	for _, copyOp := range s.copies {
+		copyArgs := copyOp.args(s.container)
+		log.Info("podman copy: " + copyOp.String())
+		if err := podmanRun(copyArgs...); err != nil {
+			exitErr := err.(*exec.ExitError)
+			log.Debug("copy into sandbox failed", "args", copyArgs, "stderr", exitErr.Stderr)
+			return fmt.Errorf("copy into sandbox [%s]  failed: %w", copyOp, err)
 		}
 	}
+
 	return nil
 }
 
@@ -519,4 +543,21 @@ func (s *podmanSandbox) Clean() error {
 		return err
 	}
 	return podmanCleanContainers()
+}
+
+// CopyToHost copies a file from the sandbox back the host (after it has run)
+// src is a path in the container and dest is a path in the host
+func (s *podmanSandbox) CopyToHost(src, dest string) error {
+	if len(s.container) == 0 {
+		return errors.New("cannot copy while container ID is empty. (Has the container been initialised?)")
+	}
+
+	copyCmd := copySpec{
+		src:             src,
+		dest:            dest,
+		srcInContainer:  true,
+		destInContainer: false,
+	}.args(s.container)
+
+	return podmanRun(copyCmd...)
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -99,7 +99,9 @@ type Sandbox interface {
 	// CopyToHost copies a path in the sandbox (src) to a path in the host (dest).
 	// It will fail if the src path does not exist in the sandbox.
 	// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for
-	// semantics of src and dest paths
+	// semantics of src and dest paths.
+	// Caution: files coming out of the sandbox are untrusted and proper validation
+	// should be performed on the file before use.
 	CopyToHost(src, dest string) error
 }
 
@@ -426,8 +428,6 @@ func (s *podmanSandbox) init() error {
 		copyArgs := copyOp.args(s.container)
 		log.Info("podman copy: " + copyOp.String())
 		if err := podmanRun(copyArgs...); err != nil {
-			exitErr := err.(*exec.ExitError)
-			log.Debug("copy into sandbox failed", "args", copyArgs, "stderr", exitErr.Stderr)
 			return fmt.Errorf("copy into sandbox [%s]  failed: %w", copyOp, err)
 		}
 	}


### PR DESCRIPTION
This PR adds a `CopyToHost` function to the `sandbox.Sandbox` interface which allows copying files from the sandbox container to the host, after the sandbox has run. This will be used in a future PR to save logs of executed functions during the dynamic analysis import phase. 

The current `copy` struct is slightly tweaked to allow dual use, and renamed to `copySpec` to avoid name shadowing. 

Also fixed an apparent bug with the existing copy implementation where multiple copies are specified - `podman cp` only supports one copy at once.