### PR TITLE
sandbox: prune images before pulling new ones

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -409,18 +409,18 @@ func (s *podmanSandbox) init() error {
 	if err := removeAllLogs(); err != nil {
 		return fmt.Errorf("failed removing all logs: %w", err)
 	}
+	if err := podmanPrune(); err != nil {
+		return fmt.Errorf("error pruning images: %w", err)
+	}
 	if !s.noPull {
 		if err := s.pullImage(); err != nil {
 			return fmt.Errorf("error pulling image: %w", err)
 		}
 	}
-	if err := podmanPrune(); err != nil {
-		return fmt.Errorf("error pruning images: %w", err)
-	}
-	if id, err := s.createContainer(); err == nil {
-		s.container = id
-	} else {
+	if id, err := s.createContainer(); err != nil {
 		return fmt.Errorf("error creating container: %w", err)
+	} else {
+		s.container = id
 	}
 
 	// run each copy command separately


### PR DESCRIPTION
Discovered as part of #741: if the sandbox fails to pull a new image, the init function will return and the `prune()` will not get called. This may cause extra space to be used. 

This PR switches the order of the two calls so that the prune comes first. Additionally, the error check of `createContainer` is changed to make it consistent in style with the other two.