### PR TITLE
log stderr from command errors, if present

### DIFF
--- a/internal/worker/logging.go
+++ b/internal/worker/logging.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"errors"
 	"os/exec"
 
 	"github.com/ossf/package-analysis/internal/analysis"
@@ -36,7 +37,8 @@ func LogDynamicAnalysisError(pkg *pkgmanager.Pkg, errorPhase analysisrun.Dynamic
 		"version", pkg.Version(),
 		"error", err)
 
-	if exitErr, ok := err.(*exec.ExitError); ok {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		log.Debug("Command stderr", "stderr", exitErr.Stderr)
 	}
 }

--- a/internal/worker/logging.go
+++ b/internal/worker/logging.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"os/exec"
+
 	"github.com/ossf/package-analysis/internal/analysis"
 	"github.com/ossf/package-analysis/internal/log"
 	"github.com/ossf/package-analysis/internal/pkgmanager"
@@ -33,6 +35,10 @@ func LogDynamicAnalysisError(pkg *pkgmanager.Pkg, errorPhase analysisrun.Dynamic
 		"name", pkg.Name(),
 		"version", pkg.Version(),
 		"error", err)
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		log.Debug("Command stderr", "stderr", exitErr.Stderr)
+	}
 }
 
 // LogDynamicAnalysisResult indicates that the package code was run successfully,


### PR DESCRIPTION
In logs, many errors coming from sandbox commands (usually during dynamic analysis) have minimal information in the error string itself. This change ensures that any stderr from these commands is also logged for debugging purposes