### PR TITLE
fix bug in dynamic analysis dockerfile workdir

### DIFF
--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -148,8 +148,9 @@ COPY analyze-rust.py .
 
 RUN chmod 755 analyze-php.php analyze-node.js analyze-python.py analyze-ruby.rb analyze-rust.py
 
+# Ensure that this the last WORKDIR statement, otherwise things like cargo will break
+WORKDIR /app
 
 # Set main cmd to 'sleep 30m'
-
 ENTRYPOINT [ "sleep" ]
 CMD [ "30m" ]


### PR DESCRIPTION
WORKDIR was changed (by me) to simplify copying of the analysis script files, but not properly restored to `/app`.

This broke some things, including causing #754. Thanks to @another-rex for diagnosing the problem!

Fixes #754.