### PR TITLE
add package downloader tool and add more error handling to download functions

### DIFF
--- a/cmd/downloader/README.md
+++ b/cmd/downloader/README.md
@@ -1,0 +1,40 @@
+
+# Package Download tool
+
+This tool enables easy batch download of many packages to a local directory,
+which may be useful for testing or running analysis locally.
+
+## Building
+
+```bash
+go build -o downloader main.go
+```
+
+## Running
+
+```bash
+./downloader -f <packages.txt> -d <dir>
+```
+
+There are two options to the downloader tool:
+
+1. List of packages to download (mandatory)
+2. Destination directory to download to (optional)
+
+If `-d` is not specified, packages will be downloaded to the current directory.
+
+The file containing the list of packages to download must have the following structure:
+
+1. Each line of the file specifies one package to download in
+   [Package URL](https://github.com/package-url/purl-spec) format
+2. Package ecosystem and name are required, version is optional
+3. If the version is not given, the latest version is downloaded
+
+Here are some examples of Package URLs (purls):
+
+- `pkg:npm/async`: NPM package `async`, no version specified
+- `pkg:pypi/requests@2.31.0`: PyPI package `requests`, version 2.31.0
+- `pkg:npm/%40babel/runtime`: NPM package `@babel/runtime` (note: percent encoding is not required by this tool)
+
+If Package URL is invalid or a package fails to download, the error will be printed but will not stop the program;
+remaining package downloads will still be attempted.

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -80,7 +80,7 @@ func run() error {
 	}
 
 	if stat, err := os.Stat(*downloadDir); err != nil {
-		return fmt.Errorf("could not stat download directory %s: %w", downloadDir, err)
+		return fmt.Errorf("could not stat download directory %s: %w", *downloadDir, err)
 	} else if !stat.IsDir() {
 		return fmt.Errorf("%s is not a directory", *downloadDir)
 	}

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/package-url/packageurl-go"
+
+	"github.com/ossf/package-analysis/internal/pkgmanager"
+	"github.com/ossf/package-analysis/internal/worker"
+	"github.com/ossf/package-analysis/pkg/api/pkgecosystem"
+)
+
+// Command-line tool to download a list of package archives, specified by purl
+// See https://github.com/package-url/purl-spec
+var (
+	packagesFile = flag.String("f", "", "file containing packages to download")
+	downloadDir  = flag.String("d", "", "directory to download files to (must exist)")
+)
+
+// usageError is a simple string error type, used when command usage
+// should be printed alongside the actual error message
+type cmdError struct {
+	message string
+}
+
+func (c *cmdError) Error() string {
+	return c.message
+}
+
+func newCmdError(message string) error {
+	return &cmdError{message}
+}
+
+func downloadPackage(purl packageurl.PackageURL, downloadDir string) error {
+	var ecosystem pkgecosystem.Ecosystem
+	if err := ecosystem.UnmarshalText([]byte(purl.Type)); err != nil {
+		return fmt.Errorf("unsupported package ecosystem for purl %s: %s", purl.String(), purl.Type)
+	}
+
+	manager := pkgmanager.Manager(ecosystem)
+	if manager == nil {
+		return fmt.Errorf("unsupported package ecosystem for purl %s: %s", purl.String(), purl.Type)
+	}
+
+	// Prepend package namespace to package name, if present
+	var pkgName string
+	if purl.Namespace != "" {
+		pkgName = purl.Namespace + "/" + purl.Name
+	} else {
+		pkgName = purl.Name
+	}
+
+	// Get the latest package version if not specified in the purl
+	pkg, err := worker.ResolvePkg(manager, pkgName, purl.Version, "")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("[%s] %s@%s\n", ecosystem, pkg.Name(), pkg.Version())
+
+	if _, err := manager.DownloadArchive(pkg.Name(), pkg.Version(), downloadDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func run() error {
+	flag.Parse()
+
+	if *packagesFile == "" {
+		return newCmdError("package list file (-f) is a required argument")
+	}
+	if *downloadDir == "" {
+		*downloadDir = "."
+	}
+
+	if stat, err := os.Stat(*downloadDir); err != nil {
+		return fmt.Errorf("could not stat download directory %s: %w", downloadDir, err)
+	} else if !stat.IsDir() {
+		return fmt.Errorf("%s is not a directory", *downloadDir)
+	}
+
+	var fileLines []string
+	if purlBytes, err := os.ReadFile(*packagesFile); err != nil {
+		return err
+	} else {
+		fileLines = strings.Split(string(purlBytes), "\n")
+	}
+
+	var purls []packageurl.PackageURL
+	for i, s := range fileLines {
+		trimmed := strings.TrimSpace(s)
+		if len(trimmed) == 0 || trimmed[0] == '#' {
+			continue
+		}
+		if purl, err := packageurl.FromString(trimmed); err != nil {
+			return fmt.Errorf("could not parse purl '%s' on line %d: %w", s, i+1, err)
+		} else {
+			purls = append(purls, purl)
+		}
+	}
+
+	for _, purl := range purls {
+		if err := downloadPackage(purl, *downloadDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		var cmdErr *cmdError
+		if errors.As(err, &cmdErr) {
+			flag.Usage()
+			fmt.Fprintf(os.Stderr, "\n")
+		}
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blendle/zapdriver v1.3.1
 	github.com/gopacket/gopacket v1.1.0
 	github.com/ossf/package-feeds v0.0.0-20211108050428-2ce6d6de33c8
+	github.com/package-url/packageurl-go v0.1.0
 	github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c
 	go.uber.org/zap v1.24.0
 	gocloud.dev v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1611,6 +1611,8 @@ github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa
 github.com/ossf/package-feeds v0.0.0-20211108050428-2ce6d6de33c8 h1:DFkiDuvMZ7BYwXbm/b0b/SVfg//1zIu3UDN1GD657jE=
 github.com/ossf/package-feeds v0.0.0-20211108050428-2ce6d6de33c8/go.mod h1:O4i4UuYUUZr0tgFEQctzrH/IQCLNKvcr54ZPwK1STZI=
 github.com/ovh/go-ovh v1.3.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
+github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
+github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/internal/pkgmanager/download.go
+++ b/internal/pkgmanager/download.go
@@ -16,7 +16,7 @@ local file is obtained from the last element of the URL path when split on the '
 On successful download, the full path to the downloaded file is returned.
 */
 func downloadToDirectory(dir string, url string) (string, error) {
-	if len(url) == 0 {
+	if url == "" {
 		return "", errors.New("url is empty")
 	}
 

--- a/internal/pkgmanager/download.go
+++ b/internal/pkgmanager/download.go
@@ -1,6 +1,7 @@
 package pkgmanager
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,13 +16,16 @@ local file is obtained from the last element of the URL path when split on the '
 On successful download, the full path to the downloaded file is returned.
 */
 func downloadToDirectory(dir string, url string) (string, error) {
-	fileName := path.Base(url)
-	filePath := filepath.Join(dir, fileName)
-	err := downloadToPath(filePath, url)
-	if err != nil {
-		return "", err
+	if len(url) == 0 {
+		return "", errors.New("url is empty")
 	}
 
+	fileName := path.Base(url)
+	filePath := filepath.Join(dir, fileName)
+
+	if err := downloadToPath(filePath, url); err != nil {
+		return "", err
+	}
 	return filePath, nil
 }
 

--- a/internal/pkgmanager/ecosystem.go
+++ b/internal/pkgmanager/ecosystem.go
@@ -81,6 +81,9 @@ func (p *PkgManager) DownloadArchive(name, version, directory string) (string, e
 	if err != nil {
 		return "", err
 	}
+	if downloadURL == "" {
+		return "", fmt.Errorf("no url found for package %s, version %s", name, version)
+	}
 
 	archivePath, err := downloadToDirectory(directory, downloadURL)
 	if err != nil {

--- a/internal/worker/resolvepackage.go
+++ b/internal/worker/resolvepackage.go
@@ -18,6 +18,9 @@ func ResolvePkg(manager *pkgmanager.PkgManager, name, version, localPath string)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get latest version for package %s: %w", name, err)
 		}
+		if pkg.Version() == "" {
+			return nil, fmt.Errorf("failed to get latest version for package %s: not found", name)
+		}
 	}
 	return pkg, nil
 }

--- a/internal/worker/resolvepackage.go
+++ b/internal/worker/resolvepackage.go
@@ -19,10 +19,10 @@ func ResolvePkg(manager *pkgmanager.PkgManager, name, version, localPath string)
 	default:
 		pkg, err = manager.Latest(name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get latest version for package %s: %w", name, err)
+			return nil, fmt.Errorf("failed to get latest version: %w", err)
 		}
 		if pkg.Version() == "" {
-			return nil, fmt.Errorf("failed to get latest version for package %s: not found", name)
+			return nil, fmt.Errorf("unknown package name '%s'", name)
 		}
 	}
 	return pkg, nil
@@ -33,12 +33,12 @@ func ResolvePkg(manager *pkgmanager.PkgManager, name, version, localPath string)
 func ResolvePurl(purl packageurl.PackageURL) (*pkgmanager.Pkg, error) {
 	var ecosystem pkgecosystem.Ecosystem
 	if err := ecosystem.UnmarshalText([]byte(purl.Type)); err != nil {
-		return nil, fmt.Errorf("unsupported package ecosystem for purl %s: %s", purl.String(), purl.Type)
+		return nil, fmt.Errorf("unsupported package ecosystem '%s'", purl.Type)
 	}
 
 	manager := pkgmanager.Manager(ecosystem)
 	if manager == nil {
-		return nil, fmt.Errorf("unsupported package ecosystem for purl %s: %s", purl.String(), purl.Type)
+		return nil, fmt.Errorf("unsupported package ecosystem '%s'", purl.Type)
 	}
 
 	// Prepend package namespace to package name, if present


### PR DESCRIPTION
Add a new tool in the `cmd` directory which allows bulk downloading of packages. Usage is by passing a file of purls specifying which packages to download.