### PR TITLE
Remove an fsync to improve the performance of file writes.

### DIFF
--- a/internal/utils/file_write_data_utils.go
+++ b/internal/utils/file_write_data_utils.go
@@ -12,10 +12,10 @@ This subfolder needs to be shared across files so all functions that access it w
 
 const writeBufferFolder = "worker_tmp/write_buffers"
 
-/*
-Writes a file in the directory specified by write_buffer_folder and flushes the buffer.
-This directory is meant to be cleaned up through the RemoveTempFilesDirectory() method.
-*/
+// CreateAndWriteTempFile writes a file in the directory specified by
+// writeBufferFolder.
+//
+// This directory is must be cleaned up with a call to RemoveTempFilesDirectory().
 func CreateAndWriteTempFile(fileName string, data []byte) error {
 	err := os.MkdirAll(writeBufferFolder, 0777)
 	if err != nil {
@@ -31,7 +31,6 @@ func CreateAndWriteTempFile(fileName string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	f.Sync()
 	return nil
 }
 

--- a/internal/utils/file_write_data_utils.go
+++ b/internal/utils/file_write_data_utils.go
@@ -28,10 +28,7 @@ func CreateAndWriteTempFile(fileName string, data []byte) error {
 	}
 	defer f.Close()
 	_, err = f.Write(data)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func OpenTempFile(fileName string) (*os.File, error) {

--- a/internal/utils/file_write_data_utils.go
+++ b/internal/utils/file_write_data_utils.go
@@ -15,7 +15,7 @@ const writeBufferFolder = "worker_tmp/write_buffers"
 // CreateAndWriteTempFile writes a file in the directory specified by
 // writeBufferFolder.
 //
-// This directory is must be cleaned up with a call to RemoveTempFilesDirectory().
+// This directory must be cleaned up with a call to RemoveTempFilesDirectory().
 func CreateAndWriteTempFile(fileName string, data []byte) error {
 	err := os.MkdirAll(writeBufferFolder, 0777)
 	if err != nil {


### PR DESCRIPTION
fsync shouldn't be necessary as we don't care about persisting the file if the process is terminated without the buffers being flushed.