### PR TITLE
Correct usage of `path` and `filepath` packages across the project

### DIFF
--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"time"
 
 	"gocloud.dev/blob"
@@ -63,11 +63,11 @@ func (rs *ResultStore) String() string {
 }
 
 func (rs *ResultStore) generatePath(p Pkg) string {
-	path := rs.basePath
+	uploadPath := rs.basePath
 	if rs.constructPath {
-		path = filepath.Join(path, p.EcosystemName(), p.Name())
+		uploadPath = path.Join(uploadPath, p.EcosystemName(), p.Name())
 	}
-	return path
+	return uploadPath
 }
 
 func (rs *ResultStore) SaveTempFilesToZip(ctx context.Context, p Pkg, fileName string, tempFileNames []string) error {
@@ -77,7 +77,7 @@ func (rs *ResultStore) SaveTempFilesToZip(ctx context.Context, p Pkg, fileName s
 	}
 	defer bkt.Close()
 
-	uploadPath := filepath.Join(rs.generatePath(p), fileName+".zip")
+	uploadPath := path.Join(rs.generatePath(p), fileName+".zip")
 	log.Info("Uploading results",
 		"bucket", rs.bucket,
 		"path", uploadPath)
@@ -191,8 +191,7 @@ func (rs *ResultStore) SaveWithFilename(ctx context.Context, p Pkg, filename str
 	}
 	defer bkt.Close()
 
-	path := rs.generatePath(p)
-	uploadPath := filepath.Join(path, filename)
+	uploadPath := path.Join(rs.generatePath(p), filename)
 	log.Info("Uploading results",
 		"bucket", rs.bucket,
 		"path", uploadPath)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -275,7 +274,7 @@ func Tag(tag string) Option {
 }
 
 func removeAllLogs() error {
-	matches, err := filepath.Glob(path.Join(os.TempDir(), logDirPattern+"*"))
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), logDirPattern+"*"))
 	if err != nil {
 		return err
 	}
@@ -349,7 +348,7 @@ func (s *podmanSandbox) startContainerCmd(logDir string) *exec.Cmd {
 		"start",
 		"--runtime=" + runtimeBin,
 		"--runtime-flag=root=" + rootDir,
-		"--runtime-flag=debug-log=" + path.Join(logDir, "runsc.log.%COMMAND%"),
+		"--runtime-flag=debug-log=" + filepath.Join(logDir, "runsc.log.%COMMAND%"),
 	}
 	if s.rawSockets {
 		args = append(args, "--runtime-flag=net-raw")
@@ -457,7 +456,7 @@ func (s *podmanSandbox) Run(command string, args ...string) (*RunResult, error) 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	result := &RunResult{
-		logPath: path.Join(logDir, runLogFile),
+		logPath: filepath.Join(logDir, runLogFile),
 		status:  RunStatusUnknown,
 		stdout:  &stdout,
 		stderr:  &stderr,

--- a/internal/staticanalysis/parsing/init_parser.go
+++ b/internal/staticanalysis/parsing/init_parser.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 
 	"github.com/ossf/package-analysis/internal/utils"
 )
@@ -61,8 +61,8 @@ func InitParser(installDir string) (ParserConfig, error) {
 	}
 
 	for _, file := range parserFiles {
-		filePath := path.Join(installDir, file.name)
-		if err := utils.WriteFile(filePath, file.contents, file.isExecutable); err != nil {
+		writePath := filepath.Join(installDir, file.name)
+		if err := utils.WriteFile(writePath, file.contents, file.isExecutable); err != nil {
 			return ParserConfig{}, fmt.Errorf("error writing %s to %s: %w", file.name, installDir, err)
 		}
 	}
@@ -83,6 +83,6 @@ func InitParser(installDir string) (ParserConfig, error) {
 
 	return ParserConfig{
 		InstallDir: installDir,
-		ParserPath: path.Join(installDir, parserFileName),
+		ParserPath: filepath.Join(installDir, parserFileName),
 	}, nil
 }

--- a/internal/utils/archive_extract.go
+++ b/internal/utils/archive_extract.go
@@ -6,23 +6,22 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/ossf/package-analysis/internal/log"
 )
 
-// ExtractTarGzFile extracts a .tar.gz / .tgz file located at path, using
-// outputDir as the root of the extracted files.
-func ExtractTarGzFile(path string, outputDir string) error {
-	return processGzipFile(path, func(reader io.Reader) error {
+// ExtractTarGzFile extracts a .tar.gz / .tgz file located at filePath,
+// using outputDir as the root of the extracted files.
+func ExtractTarGzFile(filePath string, outputDir string) error {
+	return processGzipFile(filePath, func(reader io.Reader) error {
 		return extractTar(reader, outputDir)
 	})
 }
 
-func processGzipFile(path string, process func(io.Reader) error) error {
-	gzFile, err := os.Open(path)
+func processGzipFile(filePath string, process func(io.Reader) error) error {
+	gzFile, err := os.Open(filePath)
 	if err != nil {
 		return err
 	}
@@ -41,7 +40,6 @@ func processGzipFile(path string, process func(io.Reader) error) error {
 	if err := process(unzippedBytes); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -79,7 +77,7 @@ func extractTar(tarStream io.Reader, outputDir string) error {
 
 			// ensure containing directories exist; some archives don't include an explicit entry
 			// for parent directories
-			parentDir := path.Dir(outputPath)
+			parentDir := filepath.Dir(outputPath)
 			if err = os.MkdirAll(parentDir, 0o755); err != nil {
 				return fmt.Errorf("create parent dirs for %s failed: %w", header.Name, err)
 			}

--- a/internal/utils/archive_extract_test.go
+++ b/internal/utils/archive_extract_test.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -90,8 +90,8 @@ func createTgzFile(path string, headers []*tar.Header) (err error) {
 func makePaths(t *testing.T, testName string) (workDir, archivePath, extractPath string, err error) {
 	t.Helper()
 	workDir = t.TempDir()
-	archivePath = path.Join(workDir, testName+".tar.gz")
-	extractPath = path.Join(workDir, "extracted")
+	archivePath = filepath.Join(workDir, testName+".tar.gz")
+	extractPath = filepath.Join(workDir, "extracted")
 
 	if err = os.Mkdir(extractPath, 0o700); err != nil {
 		t.Fatalf("failed to create dir for extraction: %v", err)
@@ -129,7 +129,7 @@ func TestExtractSimpleTarGzFile(t *testing.T) {
 	}
 
 	err = doExtractionTest(archivePath, extractPath, testHeaders, func() error {
-		dirInfo, err := os.Stat(path.Join(extractPath, "test"))
+		dirInfo, err := os.Stat(filepath.Join(extractPath, "test"))
 		if err != nil {
 			return fmt.Errorf("stat extracted dir: %w", err)
 		}
@@ -140,7 +140,7 @@ func TestExtractSimpleTarGzFile(t *testing.T) {
 			return fmt.Errorf("expected to extract directory but it was not a directory")
 		}
 
-		fileInfo, err := os.Stat(path.Join(extractPath, "test", "1.txt"))
+		fileInfo, err := os.Stat(filepath.Join(extractPath, "test", "1.txt"))
 		if err != nil {
 			return fmt.Errorf("stat extracted file: %w", err)
 		}
@@ -175,7 +175,7 @@ func TestExtractMissingParentDir(t *testing.T) {
 	}
 
 	err = doExtractionTest(archivePath, extractPath, testHeaders, func() error {
-		dirInfo, err := os.Stat(path.Join(extractPath, "test"))
+		dirInfo, err := os.Stat(filepath.Join(extractPath, "test"))
 		if err != nil {
 			return fmt.Errorf("stat extracted dir: %w", err)
 		}
@@ -186,7 +186,7 @@ func TestExtractMissingParentDir(t *testing.T) {
 			return fmt.Errorf("expected to extract directory but it was not a directory")
 		}
 
-		fileInfo, err := os.Stat(path.Join(extractPath, "test", "1.txt"))
+		fileInfo, err := os.Stat(filepath.Join(extractPath, "test", "1.txt"))
 		if err != nil {
 			return fmt.Errorf("stat extracted file: %w", err)
 		}
@@ -222,7 +222,7 @@ func TestExtractAbsolutePathTarGzFile(t *testing.T) {
 	}
 
 	err = doExtractionTest(archivePath, extractPath, testHeaders, func() error {
-		dirInfo, err := os.Stat(path.Join(extractPath, "test"))
+		dirInfo, err := os.Stat(filepath.Join(extractPath, "test"))
 		if err != nil {
 			return fmt.Errorf("stat extracted dir: %w", err)
 		}
@@ -233,7 +233,7 @@ func TestExtractAbsolutePathTarGzFile(t *testing.T) {
 			return fmt.Errorf("expected to extract directory but it was not a directory")
 		}
 
-		fileInfo, err := os.Stat(path.Join(extractPath, "2.txt"))
+		fileInfo, err := os.Stat(filepath.Join(extractPath, "2.txt"))
 		if err != nil {
 			return fmt.Errorf("stat extracted file: %w", err)
 		}
@@ -292,11 +292,11 @@ func TestExtractZipSlip2(t *testing.T) {
 	err = os.Mkdir(similarlyNamedDir, 0o700)
 
 	testHeaders := []*tar.Header{
-		makeFileHeader(path.Join("..", path.Base(similarlyNamedDir), "bad2.txt"), 1),
+		makeFileHeader(filepath.Join("..", filepath.Base(similarlyNamedDir), "bad2.txt"), 1),
 	}
 
 	err = doExtractionTest(archivePath, extractPath, testHeaders, func() error {
-		bad2Info, err := os.Stat(path.Join(similarlyNamedDir, "bad2.txt"))
+		bad2Info, err := os.Stat(filepath.Join(similarlyNamedDir, "bad2.txt"))
 		if err == nil && bad2Info.Size() == 1 {
 			t.Errorf("Found file in similarly named directory")
 		}
@@ -323,7 +323,7 @@ func TestExtractZipSlip3(t *testing.T) {
 	}
 
 	err = doExtractionTest(archivePath, extractPath, testHeaders, func() error {
-		bad3Info, err := os.Stat(path.Join(workDir, "bad3.txt"))
+		bad3Info, err := os.Stat(filepath.Join(workDir, "bad3.txt"))
 		if err == nil && bad3Info.Size() == 1 {
 			t.Errorf("Found file in parent directory")
 		}

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -53,7 +53,7 @@ func retrieveExecutionLog(sb sandbox.Sandbox) (string, error) {
 	}
 
 	defer os.RemoveAll(executionLogDir)
-	executionLogPath := path.Join(executionLogDir, "execution.log")
+	executionLogPath := filepath.Join(executionLogDir, "execution.log")
 
 	// if the copy fails, it could be that the execution log is not actually present.
 	// For now, we'll just log the error and otherwise ignore it

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/ossf/package-analysis/internal/log"
@@ -164,7 +164,7 @@ func run() (err error) {
 
 	extractionTime := time.Since(startExtractionTime)
 
-	jsParserConfig, parserInitErr := parsing.InitParser(path.Join(workDirs.parserDir, jsParserDirName))
+	jsParserConfig, parserInitErr := parsing.InitParser(filepath.Join(workDirs.parserDir, jsParserDirName))
 	if parserInitErr != nil {
 		log.Error("failed to init JS parser", "error", parserInitErr)
 	}


### PR DESCRIPTION
The `path` and `filepath` packages in Go have been used fairly inconsistently in the project and sometimes incorrectly. `path` is intended for OS-independent path strings such as URLs, bucket paths, etc. whereas `filepath` is used for OS paths. 

In some cases, `filepath` functions were used instead of `path`, because a variable named `path` was shadowing the package name.

If we ever decided to run package analysis in a Windows environment, these incorrect usages would break things.

This PR restores the correct usages of `path` and `filepath`, and renames some variables to avoid shadowing package names