### PR TITLE
Enable code execution for PyPI

### DIFF
--- a/internal/featureflags/features.go
+++ b/internal/featureflags/features.go
@@ -5,10 +5,16 @@ var (
 	// data during dynamic analysis.
 	WriteFileContents = new("WriteFileContents", true)
 
-	// SaveAnalyzedPackages will save analyzed package.
+	// SaveAnalyzedPackages downloads the package archive and saves it
+	// to the analyzed packages bucket (if configured) after analysis completes
 	SaveAnalyzedPackages = new("SaveAnalyzedPackages", false)
 
 	// PubSubExtender determines whether or not the worker uses a real GCP
 	// extender for keeping messages alive during long-running processing.
 	PubSubExtender = new("PubSubExtender", true)
+
+	// CodeExecution automatically invokes package code during the import phase
+	// of dynamic analysis, which may uncover extra malicious behaviour.
+	// A list executed function/method/class names is saved.
+	CodeExecution = new("CodeExecution", false)
 )

--- a/internal/sandbox/copy_args.go
+++ b/internal/sandbox/copy_args.go
@@ -1,0 +1,50 @@
+package sandbox
+
+import (
+	"fmt"
+	"strings"
+)
+
+// copySpec specifies the source and destination of a copy operation.
+// The copy may be made from the host into the sandbox or vice versa.
+// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for
+// semantics of src and dest paths.
+// srcInContainer and destInContainer specify whether the copy source
+// and destination are respectively in the host (false) or container (true)
+type copySpec struct {
+	src             string
+	dest            string
+	srcInContainer  bool
+	destInContainer bool
+	containerId     string
+}
+
+func (c copySpec) Args() []string {
+	copySrc := c.src
+	if c.srcInContainer {
+		copySrc = fmt.Sprintf("%s:%s", c.containerId, c.src)
+	}
+
+	copyDest := c.dest
+	if c.destInContainer {
+		copyDest = fmt.Sprintf("%s:%s", c.containerId, c.dest)
+	}
+
+	return []string{"cp", copySrc, copyDest}
+}
+
+func (c copySpec) String() string {
+	return strings.Join(c.Args(), " ")
+}
+
+// hostToContainerCopyCmd generates the arguments to podman
+// that copy a file from the host to the container.
+func hostToContainerCopyCmd(hostPath, containerPath, containerId string) copySpec {
+	return copySpec{hostPath, containerPath, false, true, containerId}
+}
+
+// hostToContainerCopyCmd generates the arguments to podman
+// that copy a file from the container to host.
+func containerToHostCopyCmd(hostPath, containerPath, containerId string) copySpec {
+	return copySpec{containerPath, hostPath, true, false, containerId}
+}

--- a/internal/sandbox/copy_args_test.go
+++ b/internal/sandbox/copy_args_test.go
@@ -1,0 +1,68 @@
+package sandbox
+
+import (
+	"reflect"
+	"testing"
+)
+
+type copyCmdTestCase struct {
+	name          string
+	hostPath      string
+	containerPath string
+	containerId   string
+	want          []string
+}
+
+func Test_containerToHostCopyCmdArgs(t *testing.T) {
+	tests := []copyCmdTestCase{
+		{
+			name:          "simple relative path",
+			hostPath:      "path/in/host",
+			containerPath: "path/in/container",
+			containerId:   "12345",
+			want:          []string{"cp", "12345:path/in/container", "path/in/host"},
+		},
+		{
+			name:          "simple absolute path",
+			hostPath:      "/dest/path/in/host",
+			containerPath: "/src/path/in/container",
+			containerId:   "abcde",
+			want:          []string{"cp", "abcde:/src/path/in/container", "/dest/path/in/host"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containerToHostCopyCmd(tt.hostPath, tt.containerPath, tt.containerId).Args()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("containerToHostCopyCmd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_hostToContainerCopyCmdArgs(t *testing.T) {
+	tests := []copyCmdTestCase{
+		{
+			name:          "simple relative path",
+			hostPath:      "/src",
+			containerPath: "/dest",
+			containerId:   "12345",
+			want:          []string{"cp", "/src", "12345:/dest"},
+		},
+		{
+			name:          "simple absolute path",
+			hostPath:      "/src/path/in/host",
+			containerPath: "/dest/path/in/container",
+			containerId:   "abcde",
+			want:          []string{"cp", "/src/path/in/host", "abcde:/dest/path/in/container"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostToContainerCopyCmd(tt.hostPath, tt.containerPath, tt.containerId).Args()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hostToContainerCopyCmd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -235,12 +235,8 @@ func Volume(src, dest string) Option {
 // Copy copies a file from the host into the sandbox during initialisation
 func Copy(src, dest string) Option {
 	return option(func(sb *podmanSandbox) {
-		sb.copies = append(sb.copies, copySpec{
-			src:             src,
-			dest:            dest,
-			srcInContainer:  false,
-			destInContainer: true,
-		})
+		// container ID is set later
+		sb.copies = append(sb.copies, hostToContainerCopyCmd(src, dest, ""))
 	})
 }
 

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -89,13 +89,19 @@ type Sandbox interface {
 	// Clean cleans up the Sandbox. Once called, the Sandbox cannot be used again.
 	Clean() error
 
-	// CopyToHost copies a path in the sandbox (src) to a path in the host (dest).
-	// It will fail if the src path does not exist in the sandbox.
-	// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html
-	// for semantics of src and dest paths.
+	// CopyIntoSandbox copies a path in the host to one in the sandbox. The paths
+	// may be files or directories. The copy fails if the host path does not exist.
+	// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for details
+	// on specifying paths.
+	CopyIntoSandbox(hostPath, sandboxPath string) error
+
+	// CopyBackToHost copies a path in the sandbox to one in the host. The paths
+	// may be files or directories. The copy fails if the sandbox path does not exist.
+	// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for details
+	// on specifying paths.
 	// Caution: files coming out of the sandbox are untrusted and proper validation
 	// should be performed on the file before use.
-	CopyToHost(src, dest string) error
+	CopyBackToHost(hostPath, sandboxPath string) error
 }
 
 // volume represents a volume mapping between a host src and a container dest.
@@ -109,37 +115,6 @@ func (v volume) args() []string {
 		"-v",
 		fmt.Sprintf("%s:%s", v.src, v.dest),
 	}
-}
-
-// copySpec specifies the source and destination of a copy operation.
-// The copy may be made from the host into the sandbox or vice versa.
-// See https://docs.podman.io/en/latest/markdown/podman-cp.1.html for
-// semantics of src and dest paths.
-// srcInContainer and destInContainer specify whether the copy source
-// and destination are respectively in the host (false) or container (true)
-type copySpec struct {
-	src             string
-	dest            string
-	srcInContainer  bool
-	destInContainer bool
-}
-
-func (c copySpec) args(containerId string) []string {
-	copySrc := c.src
-	if c.srcInContainer {
-		copySrc = fmt.Sprintf("%s:%s", containerId, c.src)
-	}
-
-	copyDest := c.dest
-	if c.destInContainer {
-		copyDest = fmt.Sprintf("%s:%s", containerId, c.dest)
-	}
-
-	return []string{"cp", copySrc, copyDest}
-}
-
-func (c copySpec) String() string {
-	return strings.Join(c.args("container"), " ")
 }
 
 // Implements the Sandbox interface using "podman".
@@ -422,9 +397,9 @@ func (s *podmanSandbox) init() error {
 
 	// run each copy command separately
 	for _, copyOp := range s.copies {
-		copyArgs := copyOp.args(s.container)
-		log.Info("podman copy: " + copyOp.String())
-		if err := podmanRun(copyArgs...); err != nil {
+		copyOp.containerId = s.container
+		log.Info("podman " + copyOp.String())
+		if err := podmanRun(copyOp.Args()...); err != nil {
 			return fmt.Errorf("copy into sandbox [%s]  failed: %w", copyOp, err)
 		}
 	}
@@ -542,19 +517,24 @@ func (s *podmanSandbox) Clean() error {
 	return podmanCleanContainers()
 }
 
-// CopyToHost copies a file from the sandbox back the host (after it has run)
-// src is a path in the container and dest is a path in the host
-func (s *podmanSandbox) CopyToHost(src, dest string) error {
+// CopyIntoSandbox copies a file from the host into the sandbox.
+func (s *podmanSandbox) CopyIntoSandbox(hostPath, sandboxPath string) error {
 	if len(s.container) == 0 {
 		return errors.New("cannot copy while container ID is empty. (Has the container been initialised?)")
 	}
 
-	copyCmd := copySpec{
-		src:             src,
-		dest:            dest,
-		srcInContainer:  true,
-		destInContainer: false,
-	}.args(s.container)
+	copyCmd := hostToContainerCopyCmd(hostPath, sandboxPath, s.container)
+	log.Info("podman " + copyCmd.String())
+	return podmanRun(copyCmd.Args()...)
+}
 
-	return podmanRun(copyCmd...)
+// CopyBackToHost copies a file from the sandbox back the host (after it has run)
+func (s *podmanSandbox) CopyBackToHost(hostPath, sandboxPath string) error {
+	if len(s.container) == 0 {
+		return errors.New("cannot copy while container ID is empty. (Has the container been initialised?)")
+	}
+
+	copyCmd := containerToHostCopyCmd(hostPath, sandboxPath, s.container)
+	log.Info("podman " + copyCmd.String())
+	return podmanRun(copyCmd.Args()...)
 }

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -72,13 +72,16 @@ func enableCodeExecution(sb sandbox.Sandbox) error {
 		return fmt.Errorf("could not create execution log file in host: %w", err)
 	}
 
-	if err := tempFile.Close(); err != nil {
-		return fmt.Errorf("could not close execution log file in host: %w", err)
-	}
+	// file wasn't written to so don't worry too much about close errors
+	_ = tempFile.Close()
+	tempPath := tempFile.Name()
 
-	if err := sb.CopyIntoSandbox(tempFile.Name(), sandboxExecutionLogPath); err != nil {
+	if err := sb.CopyIntoSandbox(tempPath, sandboxExecutionLogPath); err != nil {
 		return fmt.Errorf("could not copy execution log file to sandbox: %w", err)
 	}
+
+	// file wasn't written to so don't worry too much about remove errors
+	_ = os.Remove(tempPath)
 
 	return nil
 }


### PR DESCRIPTION
- create execution log file in sandbox to enable code execution for PyPI (#730)
- add feature flag for code execution
- enable bidirectional copies via sandbox interface, rename existing `CopyToHost(src, dest)` function to `CopyBackToHost(hostPath, sandboxPath)` for clarity
- encapsulate logic for `podman cp` argument generation in a separate file (sandbox/copy_args.go) and add unit tests