### PR TITLE
explicitly use `--require-hashes` in pip install command

### DIFF
--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
 
 # Some Python packages expect certain dependencies to already be installed
 COPY pypi-packages.txt ./
-RUN pip install -r pypi-packages.txt
+RUN pip install --require-hashes --requirement pypi-packages.txt
 
 
 #


### PR DESCRIPTION
This is just to silence a Scorecard warning, the actual behaviour is unchanged since the `--hash` option is already specified in the pypi-packages.txt file and this implicitly enables `--require-hashes`