### PR TITLE
More GCP PubSub tests and enable lazy nacks

### DIFF
--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -21,7 +21,7 @@ spec:
         command: ["worker"]
         env:
         - name: OSSMALWARE_WORKER_SUBSCRIPTION
-          value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers
+          value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers?nacklazy=1
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results
         - name: OSSF_MALWARE_STATIC_ANALYSIS_RESULTS

--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -21,6 +21,7 @@ spec:
         command: ["worker"]
         env:
         - name: OSSMALWARE_WORKER_SUBSCRIPTION
+          # See: https://pkg.go.dev/gocloud.dev/pubsub/gcppubsub#URLOpener
           value: gcppubsub://projects/ossf-malware-analysis/subscriptions/workers?nacklazy=1
         - name: OSSF_MALWARE_ANALYSIS_RESULTS
           value: gs://ossf-malware-analysis-results


### PR DESCRIPTION
Adds some tests to check the GCP PubSub deadline bounds test.

Also disables immediate Nack'ing of messages when an error occurs. This means that messages won't be reprocessed until their deadline expires. This ensures that errors have a small (< 10min) delay before they're retried.

This should improve the responsiveness of the pipeline to live changes, and increase the chance that transient errors are successful on subsequent attempts.