### PR TITLE
Fix bugs in execution log handling

### DIFF
--- a/internal/featureflags/features.go
+++ b/internal/featureflags/features.go
@@ -16,5 +16,5 @@ var (
 	// CodeExecution automatically invokes package code during the import phase
 	// of dynamic analysis, which may uncover extra malicious behaviour.
 	// A list executed function/method/class names is saved.
-	CodeExecution = new("CodeExecution", false)
+	CodeExecution = new("CodeExecution", true)
 )

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -515,7 +515,8 @@ func (s *podmanSandbox) Clean() error {
 	return podmanCleanContainers()
 }
 
-// CopyIntoSandbox copies a file from the host into the sandbox.
+// CopyIntoSandbox copies a path from the host into the sandbox.
+// If the source path does not exist, the command will fail with exit status 125.
 func (s *podmanSandbox) CopyIntoSandbox(hostPath, sandboxPath string) error {
 	if !s.initialised {
 		return errors.New("sandbox not initialised")
@@ -529,7 +530,8 @@ func (s *podmanSandbox) CopyIntoSandbox(hostPath, sandboxPath string) error {
 	return podmanRun(copyCmd.Args()...)
 }
 
-// CopyBackToHost copies a file from the sandbox back the host (after it has run)
+// CopyBackToHost copies a path from the sandbox back to the host (after it has run).
+// If the source path does not exist, the command will fail with exit status 125.
 func (s *podmanSandbox) CopyBackToHost(hostPath, sandboxPath string) error {
 	if !s.initialised {
 		return errors.New("sandbox not initialised")

--- a/internal/worker/rundynamic.go
+++ b/internal/worker/rundynamic.go
@@ -1,10 +1,8 @@
 package worker
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -104,13 +102,7 @@ func retrieveExecutionLog(sb sandbox.Sandbox) (string, error) {
 	// if the copy fails, it could be that the execution log is not actually present.
 	// For now, we'll just log the error and otherwise ignore it
 	if err := sb.CopyBackToHost(hostExecutionLogPath, sandboxExecutionLogPath); err != nil {
-		// log stdout if possible
-		stdout := ""
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			stdout = string(exitErr.Stderr)
-		}
-		log.Warn("Could not retrieve execution log from sandbox", "error", err, "stdout", stdout)
+		log.Warn("Could not retrieve execution log from sandbox", "error", err)
 		return "", nil
 	}
 


### PR DESCRIPTION
Some cleanups around the execution log feature

1. expose `Init()` in sandbox interface. This is needed because the copy commands require the sandbox to be initialised before the copy takes place
2. add `initialised` instance variable to `podmanSandbox` to track whether it has been initialised already, and remove explicit initialisation with null values in constructor
4. fix bug in execution log copy logic (wrong argument order)
5. consolidate result variables in RunDynamicAnalysis to avoid multiple copies of the same data
6. enable execution log feature flag by default in feature flags