### PR TITLE
Minor static analysis refactoring

### DIFF
--- a/internal/staticanalysis/obfuscation/detections/suspicious_identifiers.go
+++ b/internal/staticanalysis/obfuscation/detections/suspicious_identifiers.go
@@ -3,9 +3,9 @@ package detections
 import "regexp"
 
 var (
-	hex        = regexp.MustCompile("_0x[[:xdigit:]]{3,}")
-	numeric    = regexp.MustCompile("^[A-Za-z_]\\d{3,}")
-	singleChar = regexp.MustCompile("^[A-Za-z_]$")
+	hexIdentifier        = regexp.MustCompile("_0x[[:xdigit:]]{3,}")
+	numericIdentifier    = regexp.MustCompile("^[A-Za-z_]\\d{3,}")
+	singleCharIdentifier = regexp.MustCompile("^[A-Za-z_]$")
 )
 
 /*
@@ -16,7 +16,7 @@ but if there is a large number of suspicious identifiers (especially of the
 same type) then obfuscation is probable.
 */
 var SuspiciousIdentifierPatterns = map[string]*regexp.Regexp{
-	"hex":     hex,
-	"numeric": numeric,
-	"single":  singleChar,
+	"hex":     hexIdentifier,
+	"numeric": numericIdentifier,
+	"single":  singleCharIdentifier,
 }

--- a/internal/staticanalysis/parsing/string_regexp.go
+++ b/internal/staticanalysis/parsing/string_regexp.go
@@ -3,7 +3,6 @@ package parsing
 import (
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/ossf/package-analysis/internal/utils"
 )
@@ -25,16 +24,11 @@ var (
 	backTickQuotedString2 = regexp.MustCompile("`(?:[^`\\\\]*(?:\\\\.)?)*`")
 )
 
-func combineRegexp(regexps ...*regexp.Regexp) *regexp.Regexp {
-	patterns := utils.Transform(regexps, func(r *regexp.Regexp) string { return r.String() })
-	return regexp.MustCompile(strings.Join(patterns, "|"))
-}
+//goland:noinspection GoUnusedGlobalVariable
+var anyQuotedString = utils.CombineRegexp(singleQuotedString, doubleQuotedString, backTickQuotedString)
 
 //goland:noinspection GoUnusedGlobalVariable
-var anyQuotedString = combineRegexp(singleQuotedString, doubleQuotedString, backTickQuotedString)
-
-//goland:noinspection GoUnusedGlobalVariable
-var anyQuotedString2 = combineRegexp(singleQuotedString2, doubleQuotedString2, backTickQuotedString2)
+var anyQuotedString2 = utils.CombineRegexp(singleQuotedString2, doubleQuotedString2, backTickQuotedString2)
 
 type ExtractedStrings struct {
 	RawLiterals []string
@@ -51,14 +45,12 @@ func dequote(s string) string {
 
 func FindStringsInCode(source string, stringRegexp *regexp.Regexp) (*ExtractedStrings, error) {
 	allStrings := stringRegexp.FindAllString(source, -1)
-
-	unquotedStrings := utils.Transform(allStrings, dequote)
-
-	if allStrings != nil {
-		return &ExtractedStrings{Strings: unquotedStrings, RawLiterals: allStrings}, nil
-	} else {
+	if allStrings == nil {
 		return &ExtractedStrings{Strings: []string{}, RawLiterals: []string{}}, nil
 	}
+
+	unquotedStrings := utils.Transform(allStrings, dequote)
+	return &ExtractedStrings{Strings: unquotedStrings, RawLiterals: allStrings}, nil
 }
 
 func FindStringsInFile(filePath string, stringRegexp *regexp.Regexp) (*ExtractedStrings, error) {

--- a/internal/utils/combine_regexp.go
+++ b/internal/utils/combine_regexp.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// CombineRegexp creates a single regexp by joining the argument regexps together
+// using the | operator. Each regexp is put into a separate non-capturing group before
+// being combined.
+func CombineRegexp(regexps ...*regexp.Regexp) *regexp.Regexp {
+	patterns := Transform(regexps, func(r *regexp.Regexp) string {
+		// create a non-capturing group for each regexp
+		return "(?:" + r.String() + ")"
+	})
+	return regexp.MustCompile(strings.Join(patterns, "|"))
+}

--- a/internal/utils/combine_regexp_test.go
+++ b/internal/utils/combine_regexp_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+type combineRegexpTestCase struct {
+	name    string
+	regexps []*regexp.Regexp
+	want    *regexp.Regexp
+}
+
+func TestCombineRegexp(t *testing.T) {
+	tests := []combineRegexpTestCase{
+		{
+			name: "a b c",
+			regexps: []*regexp.Regexp{
+				regexp.MustCompile("a"),
+				regexp.MustCompile("b"),
+				regexp.MustCompile("c"),
+			},
+			want: regexp.MustCompile("(?:a)|(?:b)|(?:c)"),
+		},
+		{
+			name: "capturing groups",
+			regexps: []*regexp.Regexp{
+				regexp.MustCompile("([0-9])"),
+				regexp.MustCompile("([a-z])"),
+				regexp.MustCompile("([A-Z])"),
+			},
+			want: regexp.MustCompile("(?:([0-9]))|(?:([a-z]))|(?:([A-Z]))"),
+		},
+		{
+			name: "conjunction and capturing groups",
+			regexps: []*regexp.Regexp{
+				regexp.MustCompile("(apple|pear)"),
+				regexp.MustCompile("(red|blue)"),
+				regexp.MustCompile("(up|down)"),
+			},
+			want: regexp.MustCompile("(?:(apple|pear))|(?:(red|blue))|(?:(up|down))"),
+		},
+		{
+			name: "quantification",
+			regexps: []*regexp.Regexp{
+				regexp.MustCompile("[!@#$%^&*()]{1, 30}"),
+				regexp.MustCompile("\\s+"),
+				regexp.MustCompile("[[:xdigit:]]?"),
+			},
+			want: regexp.MustCompile("(?:[!@#$%^&*()]{1, 30})|(?:\\s+)|(?:[[:xdigit:]]?)"),
+		},
+		{
+			name: "combine regexps with quantifications",
+			regexps: []*regexp.Regexp{
+				regexp.MustCompile("(apple|pear)"),
+				regexp.MustCompile("(red|blue)"),
+				regexp.MustCompile("(up|down)"),
+			},
+			want: regexp.MustCompile("(?:(apple|pear))|(?:(red|blue))|(?:(up|down))"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CombineRegexp(tt.regexps...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CombineRegexp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR does some minor prework in anticipation of a larger PR which adds URL and IP address regex-based detection

1. Move the `combineRegexp` function to the `utils` package
2. Rename some of the suspicious identifier regexps
3. Minor logic cleanup in `FindStringsInCode` 