### PR TITLE
Remove entropy summaries and record string literal and identifier entropy as part of parsing phase

### DIFF
--- a/internal/staticanalysis/linelengths/line_lengths.go
+++ b/internal/staticanalysis/linelengths/line_lengths.go
@@ -5,13 +5,11 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/ossf/package-analysis/internal/utils/valuecounts"
 )
 
 /*
 GetLineLengths counts the number of characters on each line of a file or string,
-returning a map of length to the number of lines in the file with that length.
+returning a slice containing the length of each line in sequence.
 
 Lines are defined to be separated by newline ('\n') characters. If the newline
 character is preceded by a carriage return ('\r'), this will also be treated as
@@ -24,7 +22,7 @@ Note: there may not be much useful information to be gathered by distinguishing
 between line lengths when they get very long. It may be pragmatic to just report
 all lines above e.g. 64K as 64K long.
 */
-func GetLineLengths(filePath string, sourceString string) (valuecounts.ValueCounts, error) {
+func GetLineLengths(filePath string, sourceString string) ([]int, error) {
 	var reader *bufio.Reader
 	if len(filePath) > 0 {
 		file, err := os.Open(filePath)
@@ -38,7 +36,7 @@ func GetLineLengths(filePath string, sourceString string) (valuecounts.ValueCoun
 		reader = bufio.NewReader(strings.NewReader(sourceString))
 	}
 
-	lengths := valuecounts.ValueCounts{}
+	lengths := make([]int, 0)
 	for {
 		/* Normally bufio.Scanner would be more convenient to use here, however by default
 		it uses a fixed maximum buffer size (MaxScanTokenSize = 64 * 1024). Since some
@@ -61,7 +59,7 @@ func GetLineLengths(filePath string, sourceString string) (valuecounts.ValueCoun
 				}
 				l -= drop
 			}
-			lengths[l]++
+			lengths = append(lengths, l)
 		}
 
 		if readErr == io.EOF {
@@ -71,7 +69,7 @@ func GetLineLengths(filePath string, sourceString string) (valuecounts.ValueCoun
 
 	if len(lengths) == 0 {
 		// define the empty string to have a single empty line
-		lengths[0] = 1
+		lengths = append(lengths, 0)
 	}
 
 	return lengths, nil

--- a/internal/staticanalysis/linelengths/line_lengths_test.go
+++ b/internal/staticanalysis/linelengths/line_lengths_test.go
@@ -3,15 +3,13 @@ package linelengths
 import (
 	"reflect"
 	"testing"
-
-	"github.com/ossf/package-analysis/internal/utils/valuecounts"
 )
 
 func TestSourceStringLineLengths(t *testing.T) {
 	tests := []struct {
 		name    string
 		source  string
-		want    valuecounts.ValueCounts
+		want    []int
 		wantErr bool
 	}{
 		{
@@ -23,39 +21,39 @@ Three
 Four
 Five
 `,
-			want:    map[int]int{0: 1, 3: 2, 4: 2, 5: 1},
+			want:    []int{0, 3, 3, 5, 4, 4},
 			wantErr: false,
 		},
 		{
 			name:    "test simple single line",
 			source:  `One Two Three Four Five`,
-			want:    map[int]int{23: 1},
+			want:    []int{23},
 			wantErr: false,
 		},
 		{
 			name:    "test empty string",
 			source:  ``,
-			want:    map[int]int{0: 1},
+			want:    []int{0},
 			wantErr: false,
 		},
 		{
 			name:    "test single char",
 			source:  "a",
-			want:    map[int]int{1: 1},
+			want:    []int{1},
 			wantErr: false,
 		},
 		{
 			name: "test empty newline",
 			source: `
 `,
-			want:    map[int]int{0: 1},
+			want:    []int{0},
 			wantErr: false,
 		},
 
 		{
 			name:    "test carriage return",
 			source:  "\r\n",
-			want:    map[int]int{0: 1},
+			want:    []int{0},
 			wantErr: false,
 		},
 	}

--- a/internal/staticanalysis/obfuscation/analyze.go
+++ b/internal/staticanalysis/obfuscation/analyze.go
@@ -22,8 +22,6 @@ func Analyze(parseData []*parsing.SingleResult) Result {
 		case parsing.JavaScript:
 			signals := ComputeFileSignals(*fileData)
 			signals.Filename = fileData.Filename
-			// remove NaNs for JSON
-			RemoveNaNs(&signals)
 			result.Signals = append(result.Signals, signals)
 		}
 	}

--- a/internal/staticanalysis/obfuscation/stats/sample_statistics.go
+++ b/internal/staticanalysis/obfuscation/stats/sample_statistics.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/ossf/package-analysis/internal/utils"
+	"github.com/ossf/package-analysis/internal/utils/valuecounts"
 )
 
 type RealNumber interface {
@@ -209,8 +210,8 @@ func Summarise[T RealNumber](sample []T) SampleStatistics {
 	return SampleStatistics{Size: l, Mean: m, Variance: v, Skewness: s, Quartiles: q}
 }
 
-func CountDistinct[T constraints.Integer](sample []T) map[T]int {
-	counts := make(map[T]int, 0)
+func CountDistinct(sample []int) valuecounts.ValueCounts {
+	counts := valuecounts.New()
 	for _, t := range sample {
 		counts[t] += 1
 	}

--- a/internal/staticanalysis/obfuscation/stats/sample_statistics_test.go
+++ b/internal/staticanalysis/obfuscation/stats/sample_statistics_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/ossf/package-analysis/internal/utils/valuecounts"
 )
 
 func TestSummary(t *testing.T) {
@@ -117,7 +119,7 @@ func TestSummary7(t *testing.T) {
 func TestCountDistinct1(t *testing.T) {
 	data := []int{1, 2, 3, 4, 3, 2, 1, 2}
 	actual := CountDistinct(data)
-	expected := map[int]int{1: 2, 2: 3, 3: 2, 4: 1}
+	expected := valuecounts.ValueCounts{1: 2, 2: 3, 3: 2, 4: 1}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected counts: %v\nactual counts %v\n", expected, actual)
 	}
@@ -126,7 +128,7 @@ func TestCountDistinct1(t *testing.T) {
 func TestCountDistinct2(t *testing.T) {
 	data := []int{1}
 	actual := CountDistinct(data)
-	expected := map[int]int{1: 1}
+	expected := valuecounts.ValueCounts{1: 1}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected counts: %v\nactual counts %v\n", expected, actual)
 	}
@@ -135,7 +137,7 @@ func TestCountDistinct2(t *testing.T) {
 func TestCountDistinct3(t *testing.T) {
 	data := []int{}
 	actual := CountDistinct(data)
-	expected := map[int]int{}
+	expected := valuecounts.ValueCounts{}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected counts: %v\nactual counts %v\n", expected, actual)
 	}

--- a/internal/staticanalysis/token/tokens.go
+++ b/internal/staticanalysis/token/tokens.go
@@ -1,8 +1,9 @@
 package token
 
 type Identifier struct {
-	Name string
-	Type IdentifierType
+	Name    string
+	Type    IdentifierType
+	Entropy float64
 }
 
 type Comment struct {
@@ -10,8 +11,9 @@ type Comment struct {
 }
 
 type String struct {
-	Value string
-	Raw   string
+	Value   string
+	Raw     string
+	Entropy float64
 }
 
 type Int struct {

--- a/internal/utils/valuecounts/value_counts.go
+++ b/internal/utils/valuecounts/value_counts.go
@@ -3,6 +3,7 @@ package valuecounts
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -24,6 +25,25 @@ type Pair struct {
 
 func New() ValueCounts {
 	return ValueCounts{}
+}
+
+// Count produces a new ValueCounts by counting repetitions of values in the input data
+func Count(data []int) ValueCounts {
+	vc := New()
+	for _, value := range data {
+		vc[value] += 1
+	}
+	return vc
+}
+
+// String() returns a string representation of this ValueCounts
+// with values sorted in ascending order
+func (vc ValueCounts) String() string {
+	pairStrings := make([]string, 0, len(vc))
+	for _, pair := range vc.ToPairs() {
+		pairStrings = append(pairStrings, fmt.Sprintf("%d: %d", pair.Value, pair.Count))
+	}
+	return "[" + strings.Join(pairStrings, ", ") + " ]"
 }
 
 // ToPairs converts this ValueCounts into a list of (value, count) pairs.


### PR DESCRIPTION
Follow up to #838 as part of #836. Fixes #834 

High level changes:
1. move entropy calculations from obfuscation to parsing stage
2. fix bug in string entropy calculation
3. restructure tests for obfuscation.FileData
4. make GetLineLengths return integer slice rather than counted values
5. fix more json names
6. Don't use dict in `obfuscation.FileSignals` for suspicious identifiers

Still to do: improve unit tests for obfuscation.Analyze (e.g. URLs and IP address detection)