### PR TITLE
JS parsing: Improve handling of string templates

### DIFF
--- a/internal/staticanalysis/parsing/js_parsing_test.go
+++ b/internal/staticanalysis/parsing/js_parsing_test.go
@@ -62,13 +62,11 @@ function test() {
 				{"String", "string", "hello'7'", `'hello\'7\''`, false, token.Position{9, 20}},
 				{"String", "string", "hello", `"hello"`, false, token.Position{10, 20}},
 				{"String", "string", "8", `"8"`, false, token.Position{10, 30}},
-				{"StringTemplate", "string", "hello9", `hello9`, false, token.Position{11, 21}},
-				{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{12, 22}},
-				{"StringTemplate", "string", "\"'", `"'`, false, token.Position{12, 34}},
+				{"StringTemplate", "string", "hello9", "`hello9`", false, token.Position{11, 20}},
+				{"StringTemplate", "string", "hello\"'${}\"'", "`hello\"'${}\"'`", false, token.Position{12, 21}},
 				{"Numeric", "float64", 10.0, "10", false, token.Position{12, 31}},
-				{"StringTemplate", "string", "hello\n//\"'11\"'", `hello` + "\n" + `//"'11"'`, false, token.Position{13, 19}},
-				{"StringTemplate", "string", "hello\"'", `hello"'`, false, token.Position{15, 19}},
-				{"StringTemplate", "string", "\"'", `"'`, false, token.Position{15, 38}},
+				{"StringTemplate", "string", "hello\n//\"'11\"'", "`hello\n//\"'11\"'`", false, token.Position{13, 18}},
+				{"StringTemplate", "string", "hello\"'${}\"'", "`hello\"'${}\"'`", false, token.Position{15, 18}},
 				{"Numeric", "float64", 5.6, "5.6", false, token.Position{15, 28}},
 				{"Numeric", "float64", 6.4, "6.4", false, token.Position{15, 34}},
 			},
@@ -370,6 +368,28 @@ a = w w;
 				},
 			},
 		},
+		printJSON: false,
+	},
+	{
+		name: "more string templates",
+		inputJS: "console.log(`the operation ${1} \\u2297 ${2} equals ${5}`);\n" +
+			"console.log(`\\u{54}\\u0065\\x78t`);",
+		want: singleParseData{
+			ValidInput: true,
+			Identifiers: []parsedIdentifier{
+				{"Member", "log", token.Position{1, 8}},
+				{"Member", "log", token.Position{2, 8}},
+			},
+			Literals: []parsedLiteral[any]{
+				{"StringTemplate", "string", "the operation ${} ⊗ ${} equals ${}",
+					"`the operation ${} \\u2297 ${} equals ${}`", false, token.Position{1, 12}},
+				{"Numeric", "float64", 1.0, "1", false, token.Position{1, 29}},
+				{"Numeric", "float64", 2.0, "2", false, token.Position{1, 41}},
+				{"Numeric", "float64", 5.0, "5", false, token.Position{1, 53}},
+				{"StringTemplate", "string", "Text", "`\\u{54}\\u0065\\x78t`", false, token.Position{2, 12}},
+			},
+		},
+
 		printJSON: false,
 	},
 }

--- a/internal/staticanalysis/parsing/parsing_types.go
+++ b/internal/staticanalysis/parsing/parsing_types.go
@@ -29,11 +29,20 @@ type tokenType string
 type statusType string
 
 const (
-	identifier tokenType  = "Identifier" // source code identifier (variable, class, function name)
-	literal    tokenType  = "Literal"    // source code data (string, integer, floating point literals)
-	comment    tokenType  = "Comment"    // source code comments
-	parseInfo  statusType = "Info"       // information about the parsing (e.g. number of bytes read by parser)
-	parseError statusType = "Error"      // any error encountered by parser; some are recoverable and some are not
+	// identifier means a name, e.g. variable, class, function name
+	identifier tokenType = "Identifier"
+
+	// literal means data, e.g. string, integer, floating point literals.
+	literal tokenType = "Literal"
+
+	// comment means any comment in the source code
+	comment tokenType = "Comment"
+
+	// parseInfo means any metadata about the parsing, e.g. number of bytes read by parser.
+	parseInfo statusType = "Info"
+
+	// parseError means any error encountered during parsing. It may be recoverable from, or may not
+	parseError statusType = "Error"
 )
 
 type parsedIdentifier struct {


### PR DESCRIPTION
Previously, string templates ended up as separate strings in the static analysis output. This PR changes the behaviour of string template parsing to keep the overall template string intact. Template expressions are replaced with the a placeholder string `"${}"` to avoid arbitrary code appearing in the processed string literal.

Some other minor improvements to comments in parsing_types.go and avoiding a panic in js_parsing.go are also included