### PR TITLE
Add xxd to dynamic analysis sandbox.

### DIFF
--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
 	telnet \
 	tshark \
 	software-properties-common \
+	xxd \
 	zip
 
 # Configure sudo for passwordless execution


### PR DESCRIPTION
Some malware fails when it calls "xxd" which is missing in the image. This change adds the command "xxd" to the dynamic analysis sandbox.