### PR TITLE
Make explicit top-level structs for serialised analysis results

### DIFF
--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -1,33 +1,38 @@
 [
   {
-    "name": "Package",
-    "mode": "NULLABLE",
+    "name": "schema_version",
+    "mode": "REQUIRED",
+    "type": "STRING"
+  },
+  {
+    "name": "key",
+    "mode": "REQUIRED",
     "type": "RECORD",
     "fields": [
       {
-        "name": "Ecosystem",
-        "mode": "NULLABLE",
+        "name": "ecosystem",
+        "mode": "REQUIRED",
         "type": "STRING"
       },
       {
-        "name": "Name",
-        "mode": "NULLABLE",
+        "name": "name",
+        "mode": "REQUIRED",
         "type": "STRING"
       },
       {
-        "name": "Version",
-        "mode": "NULLABLE",
+        "name": "version",
+        "mode": "REQUIRED",
         "type": "STRING"
+      },
+      {
+        "name": "created",
+        "mode": "REQUIRED",
+        "type": "TIMESTAMP"
       }
     ]
   },
   {
-    "name": "CreatedTimestamp",
-    "mode": "NULLABLE",
-    "type": "TIMESTAMP"
-  },
-  {
-    "name": "Analysis",
+    "name": "results",
     "mode": "NULLABLE",
     "type": "RECORD",
     "fields": [

--- a/internal/resultstore/result.go
+++ b/internal/resultstore/result.go
@@ -1,22 +1,44 @@
 package resultstore
 
+import (
+	"time"
+)
+
 // Pkg describes the various package details used to populate the package part
 // of the analysis results.
 type Pkg interface {
+	EcosystemName() string
 	Name() string
 	Version() string
-	EcosystemName() string
 }
 
 // pkg is an internal representation of a Pkg, which can be marshalled into JSON.
 type pkg struct {
-	Name      string
-	Version   string
-	Ecosystem string
+	Ecosystem string `json:"Ecosystem"`
+	Name      string `json:"Name"`
+	Version   string `json:"Version"`
 }
 
-type result struct {
-	Package          pkg
-	CreatedTimestamp int64
-	Analysis         interface{}
+// Key is a new version of analysisrun.Key with more fields and is serialised with different JSON keys
+type Key struct {
+	Ecosystem string    `json:"ecosystem"`
+	Name      string    `json:"name"`
+	Version   string    `json:"version"`
+	Created   time.Time `json:"created"`
+}
+
+// DynamicAnalysisRecord is the top-level struct which is serialised to produce JSON results files
+// for dynamic analysis
+type DynamicAnalysisRecord struct {
+	Package          pkg   `json:"Package"`
+	CreatedTimestamp int64 `json:"CreatedTimestamp"`
+	Analysis         any   `json:"Analysis"`
+}
+
+// StaticAnalysisRecord is the top-level struct which is serialised to produce JSON results files
+// for static analysis
+type StaticAnalysisRecord struct {
+	SchemaVersion string `json:"schema_version"`
+	Key           Key    `json:"key"`
+	Results       any    `json:"results"`
 }

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -237,9 +237,9 @@ func DefaultFilename(p Pkg) string {
 	return "results.json"
 }
 
-// SaveAnalysis wraps the analysis object with the DynamicAnalysisRecord struct and saves it to the bucket
+// SaveDynamicAnalysis wraps the analysis object with the DynamicAnalysisRecord struct and saves it to the bucket
 // using saveWithFilename. If filename is empty, a default filename (chosen using DefaultFilename) is used.
-func (rs *ResultStore) SaveAnalysis(ctx context.Context, p Pkg, analysis any, filename string) error {
+func (rs *ResultStore) SaveDynamicAnalysis(ctx context.Context, p Pkg, analysis any, filename string) error {
 	if filename == "" {
 		filename = DefaultFilename(p)
 	}

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -191,23 +191,14 @@ func (rs *ResultStore) SaveAnalyzedPackage(ctx context.Context, manager *pkgmana
 	return nil
 }
 
-// SaveWithFilename saves results to the bucket with the given filename
-func (rs *ResultStore) SaveWithFilename(ctx context.Context, p Pkg, filename string, analysis any) error {
+// saveWithFilename marshals the given data to JSON and saves the marshalled data to the bucket,
+// with the given filename / key. No processing is done on the data object.
+func (rs *ResultStore) saveWithFilename(ctx context.Context, p Pkg, data any, filename string) error {
 	if filename == "" {
 		return errors.New("filename cannot be empty")
 	}
 
-	result := &result{
-		Package: pkg{
-			Name:      p.Name(),
-			Ecosystem: p.EcosystemName(),
-			Version:   p.Version(),
-		},
-		CreatedTimestamp: time.Now().UTC().Unix(),
-		Analysis:         analysis,
-	}
-
-	b, err := json.Marshal(result)
+	b, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
@@ -233,17 +224,56 @@ func (rs *ResultStore) SaveWithFilename(ctx context.Context, p Pkg, filename str
 	}
 
 	return nil
+
 }
 
-// Save marshals the given analysis results to JSON and writes them to
-// the bucket with a default filename (key). If p is non-nil and has a
-// version specified, the default filename is <version>.json.
+// DefaultFilename returns the basename (i.e. without directory-like prefixes) of the default filename (key)
+// used to store results. If p is non-nil and has a version specified, the default filename is <version>.json.
 // Otherwise, it is "results.json".
-func (rs *ResultStore) Save(ctx context.Context, p Pkg, analysis interface{}) error {
-	filename := "results.json"
+func DefaultFilename(p Pkg) string {
 	if p != nil && p.Version() != "" {
-		filename = p.Version() + ".json"
+		return p.Version() + ".json"
+	}
+	return "results.json"
+}
+
+// SaveAnalysis wraps the analysis object with the DynamicAnalysisRecord struct and saves it to the bucket
+// using saveWithFilename. If filename is empty, a default filename (chosen using DefaultFilename) is used.
+func (rs *ResultStore) SaveAnalysis(ctx context.Context, p Pkg, analysis any, filename string) error {
+	if filename == "" {
+		filename = DefaultFilename(p)
 	}
 
-	return rs.SaveWithFilename(ctx, p, filename, analysis)
+	data := &DynamicAnalysisRecord{
+		Package: pkg{
+			Ecosystem: p.EcosystemName(),
+			Name:      p.Name(),
+			Version:   p.Version(),
+		},
+		CreatedTimestamp: time.Now().UTC().Unix(),
+		Analysis:         analysis,
+	}
+
+	return rs.saveWithFilename(ctx, p, data, filename)
+}
+
+// SaveStaticAnalysis wraps the analysis object with the result struct and saves it to the bucket
+// using saveWithFilename. If filename is empty, a default filename (chosen using DefaultFilename) is used.
+func (rs *ResultStore) SaveStaticAnalysis(ctx context.Context, p Pkg, analysis any, filename string) error {
+	if filename == "" {
+		filename = DefaultFilename(p)
+	}
+
+	data := &StaticAnalysisRecord{
+		SchemaVersion: "1",
+		Key: Key{
+			Ecosystem: p.EcosystemName(),
+			Name:      p.Name(),
+			Version:   p.Version(),
+			Created:   time.Now().UTC(),
+		},
+		Results: analysis,
+	}
+
+	return rs.saveWithFilename(ctx, p, data, filename)
 }

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -33,7 +33,7 @@ const resultsJSONFile = "/results.json"
 //
 // To run all available static analyses, pass staticanalysis.All as tasks.
 // Use sbOpts to customise sandbox behaviour.
-func RunStaticAnalysis(ctx context.Context, pkg *pkgmanager.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (analysisrun.StaticAnalysisResults, analysis.Status, error) {
+func RunStaticAnalysis(ctx context.Context, pkg *pkgmanager.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (analysisrun.StaticAnalysisData, analysis.Status, error) {
 	ctx = log.ContextWithAttrs(ctx, slog.String("mode", "static"))
 
 	slog.InfoContext(ctx, "Running static analysis", "tasks", tasks)

--- a/internal/worker/runstatic.go
+++ b/internal/worker/runstatic.go
@@ -33,7 +33,7 @@ const resultsJSONFile = "/results.json"
 //
 // To run all available static analyses, pass staticanalysis.All as tasks.
 // Use sbOpts to customise sandbox behaviour.
-func RunStaticAnalysis(ctx context.Context, pkg *pkgmanager.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (analysisrun.StaticAnalysisData, analysis.Status, error) {
+func RunStaticAnalysis(ctx context.Context, pkg *pkgmanager.Pkg, sbOpts []sandbox.Option, tasks ...staticanalysis.Task) (analysisrun.StaticAnalysisResults, analysis.Status, error) {
 	ctx = log.ContextWithAttrs(ctx, slog.String("mode", "static"))
 
 	slog.InfoContext(ctx, "Running static analysis", "tasks", tasks)

--- a/internal/worker/save_data.go
+++ b/internal/worker/save_data.go
@@ -31,7 +31,7 @@ func SaveDynamicAnalysisData(ctx context.Context, pkg *pkgmanager.Pkg, dest *Res
 		return nil
 	}
 
-	if err := dest.DynamicAnalysis.Save(ctx, pkg, data.StraceSummary); err != nil {
+	if err := dest.DynamicAnalysis.SaveAnalysis(ctx, pkg, data.StraceSummary, ""); err != nil {
 		return fmt.Errorf("failed to save strace data to %s: %w", dest.DynamicAnalysis, err)
 	}
 	if err := saveExecutionLog(ctx, pkg, dest, data); err != nil {
@@ -71,7 +71,7 @@ func saveExecutionLog(ctx context.Context, pkg *pkgmanager.Pkg, dest *ResultStor
 		execLogFilename = fmt.Sprintf("execution-log-%s.json", pkg.Version())
 	}
 
-	if err := dest.DynamicAnalysis.SaveWithFilename(ctx, pkg, execLogFilename, data.ExecutionLog); err != nil {
+	if err := dest.DynamicAnalysis.SaveAnalysis(ctx, pkg, data.ExecutionLog, execLogFilename); err != nil {
 		return fmt.Errorf("failed to save execution log to %s: %w", dest.DynamicAnalysis, err)
 	}
 
@@ -84,7 +84,7 @@ func SaveStaticAnalysisData(ctx context.Context, pkg *pkgmanager.Pkg, dest *Resu
 		return nil
 	}
 
-	if err := dest.StaticAnalysis.Save(ctx, pkg, data); err != nil {
+	if err := dest.StaticAnalysis.SaveStaticAnalysis(ctx, pkg, data, ""); err != nil {
 		return fmt.Errorf("failed to save static analysis results to %s: %w", dest.StaticAnalysis, err)
 	}
 

--- a/internal/worker/save_data.go
+++ b/internal/worker/save_data.go
@@ -31,7 +31,7 @@ func SaveDynamicAnalysisData(ctx context.Context, pkg *pkgmanager.Pkg, dest *Res
 		return nil
 	}
 
-	if err := dest.DynamicAnalysis.SaveAnalysis(ctx, pkg, data.StraceSummary, ""); err != nil {
+	if err := dest.DynamicAnalysis.SaveDynamicAnalysis(ctx, pkg, data.StraceSummary, ""); err != nil {
 		return fmt.Errorf("failed to save strace data to %s: %w", dest.DynamicAnalysis, err)
 	}
 	if err := saveExecutionLog(ctx, pkg, dest, data); err != nil {
@@ -71,7 +71,7 @@ func saveExecutionLog(ctx context.Context, pkg *pkgmanager.Pkg, dest *ResultStor
 		execLogFilename = fmt.Sprintf("execution-log-%s.json", pkg.Version())
 	}
 
-	if err := dest.DynamicAnalysis.SaveAnalysis(ctx, pkg, data.ExecutionLog, execLogFilename); err != nil {
+	if err := dest.DynamicAnalysis.SaveDynamicAnalysis(ctx, pkg, data.ExecutionLog, execLogFilename); err != nil {
 		return fmt.Errorf("failed to save execution log to %s: %w", dest.DynamicAnalysis, err)
 	}
 

--- a/internal/worker/savefilewriteresults.go
+++ b/internal/worker/savefilewriteresults.go
@@ -17,7 +17,7 @@ func saveFileWriteResults(rs *resultstore.ResultStore, ctx context.Context, pkg 
 		return errors.New("resultstore is nil")
 	}
 
-	if err := rs.Save(ctx, pkg, dynamicResults.FileWritesSummary); err != nil {
+	if err := rs.SaveAnalysis(ctx, pkg, dynamicResults.FileWritesSummary, ""); err != nil {
 		return fmt.Errorf("failed to upload file write analysis to blobstore = %w", err)
 	}
 	var allPhasesWriteBufferIdsArray []string

--- a/internal/worker/savefilewriteresults.go
+++ b/internal/worker/savefilewriteresults.go
@@ -17,7 +17,7 @@ func saveFileWriteResults(rs *resultstore.ResultStore, ctx context.Context, pkg 
 		return errors.New("resultstore is nil")
 	}
 
-	if err := rs.SaveAnalysis(ctx, pkg, dynamicResults.FileWritesSummary, ""); err != nil {
+	if err := rs.SaveDynamicAnalysis(ctx, pkg, dynamicResults.FileWritesSummary, ""); err != nil {
 		return fmt.Errorf("failed to upload file write analysis to blobstore = %w", err)
 	}
 	var allPhasesWriteBufferIdsArray []string


### PR DESCRIPTION
1. Introduce new top-level schema for static analysis data, consisting of `schema_version`, `key`, and `results` fields. `key` is an enhanced version of the `resultstore.pkg` struct which contains `ecosystem`, `name`, `version` fields to identify the package, and a `created` timestamp to store the analysis time. 
2. Make explicit `StaticAnalysisRecord` struct for serialised static analysis data that implements the above schema
3. Rename existing and `resultstore.result` struct to `DynamicAnalysisRecord` to match the static analysis one
4. Refactor save functions in ResultStore to identify which record struct is used, and extract default filename logic to its own function