### PR TITLE
move `created` field to top level in static analysis schema 

### DIFF
--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -5,6 +5,11 @@
     "type": "STRING"
   },
   {
+    "name": "created",
+    "mode": "REQUIRED",
+    "type": "TIMESTAMP"
+  },
+  {
     "name": "key",
     "mode": "REQUIRED",
     "type": "RECORD",
@@ -24,11 +29,6 @@
         "mode": "REQUIRED",
         "type": "STRING"
       },
-      {
-        "name": "created",
-        "mode": "REQUIRED",
-        "type": "TIMESTAMP"
-      }
     ]
   },
   {

--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -28,7 +28,7 @@
         "name": "version",
         "mode": "REQUIRED",
         "type": "STRING"
-      },
+      }
     ]
   },
   {

--- a/internal/resultstore/result.go
+++ b/internal/resultstore/result.go
@@ -19,12 +19,11 @@ type pkg struct {
 	Version   string `json:"Version"`
 }
 
-// Key is a new version of analysisrun.Key with more fields and is serialised with different JSON keys
+// Key is a new version of analysisrun.Key which is serialised with different JSON key names.
 type Key struct {
-	Ecosystem string    `json:"ecosystem"`
-	Name      string    `json:"name"`
-	Version   string    `json:"version"`
-	Created   time.Time `json:"created"`
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
 }
 
 // DynamicAnalysisRecord is the top-level struct which is serialised to produce JSON results files
@@ -38,7 +37,8 @@ type DynamicAnalysisRecord struct {
 // StaticAnalysisRecord is the top-level struct which is serialised to produce JSON results files
 // for static analysis
 type StaticAnalysisRecord struct {
-	SchemaVersion string `json:"schema_version"`
-	Key           Key    `json:"key"`
-	Results       any    `json:"results"`
+	SchemaVersion string    `json:"schema_version"`
+	Created       time.Time `json:"created"`
+	Key           Key       `json:"key"`
+	Results       any       `json:"results"`
 }

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -266,11 +266,11 @@ func (rs *ResultStore) SaveStaticAnalysis(ctx context.Context, p Pkg, analysis a
 
 	data := &StaticAnalysisRecord{
 		SchemaVersion: "1",
+		Created:       time.Now().UTC(),
 		Key: Key{
 			Ecosystem: p.EcosystemName(),
 			Name:      p.Name(),
 			Version:   p.Version(),
-			Created:   time.Now().UTC(),
 		},
 		Results: analysis,
 	}


### PR DESCRIPTION
This field needs to be at the top level in order to allow BigQuery to do time-based partitioning of the data