### PR TITLE
Add parsed string value to EscapedStrings struct

### DIFF
--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -271,14 +271,19 @@
                 "type": "RECORD",
                 "fields": [
                   {
-                    "name": "raw_literal",
+                    "name": "value",
                     "mode": "REQUIRED",
                     "type": "STRING"
                   },
                   {
-                    "name": "levenshtein_ratio",
+                    "name": "raw",
+                    "mode": "REQUIRED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "levenshtein_dist",
                     "mode": "NULLABLE",
-                    "type": "FLOAT64"
+                    "type": "INTT64"
                   }
                 ]
               },

--- a/internal/staticanalysis/signals/detections/escape_sequences.go
+++ b/internal/staticanalysis/signals/detections/escape_sequences.go
@@ -3,8 +3,6 @@ package detections
 import (
 	"regexp"
 
-	"github.com/texttheater/golang-levenshtein/levenshtein"
-
 	"github.com/ossf/package-analysis/internal/staticanalysis/token"
 )
 
@@ -44,19 +42,4 @@ func IsHighlyEscaped(s token.String, thresholdCount int, thresholdFrequency floa
 
 	length := float64(len([]rune(s.Value))) // convert to rune slice first to count codepoints, not bytes
 	return escapeCount >= thresholdCount || float64(escapeCount)/length >= thresholdFrequency
-}
-
-/*
-LevenshteinRatio returns the Levenshtein ratio between the parsed and raw versions
-of a string literal. This quantity is defined for two strings 'source' and 'target' as
-
-(sourceLength + targetLength - distance) / (sourceLength + targetLength)
-
-where 'distance' refers to Levenshtein (edit) distance. The particular version of
-Levenshtein distance used counts substitution as 2 operations (deletion and addition).
-*/
-func LevenshteinRatio(s token.String) float64 {
-	source := []rune(s.Raw)
-	target := []rune(s.Value)
-	return levenshtein.RatioForStrings(source, target, levenshtein.DefaultOptions)
 }

--- a/internal/staticanalysis/signals/file_signals.go
+++ b/internal/staticanalysis/signals/file_signals.go
@@ -71,8 +71,9 @@ func (s FileSignals) String() string {
 }
 
 type EscapedString struct {
-	RawLiteral       string  `json:"raw_literal"`
-	LevenshteinRatio float64 `json:"levenshtein_ratio"`
+	Value           string `json:"value"`
+	Raw             string `json:"raw"`
+	LevenshteinDist int    `json:"levenshtein_dist"`
 }
 
 // SuspiciousIdentifier is an identifier that matches a specific rule intended
@@ -132,8 +133,9 @@ func ComputeFileSignals(parseData parsing.SingleResult) FileSignals {
 		signals.EmailAddresses = append(signals.EmailAddresses, detections.FindEmailAddresses(sl.Value)...)
 		if detections.IsHighlyEscaped(sl, 8, 0.25) {
 			escapedString := EscapedString{
-				RawLiteral:       sl.Raw,
-				LevenshteinRatio: detections.LevenshteinRatio(sl),
+				Value:           sl.Value,
+				Raw:             sl.Raw,
+				LevenshteinDist: sl.LevenshteinDist(),
 			}
 			signals.EscapedStrings = append(signals.EscapedStrings, escapedString)
 		}

--- a/internal/staticanalysis/signals/file_signals_test.go
+++ b/internal/staticanalysis/signals/file_signals_test.go
@@ -17,6 +17,21 @@ type fileSignalsTestCase struct {
 
 var fileSignalsTestCases = []fileSignalsTestCase{
 	{
+		name:      "empty",
+		parseData: parsing.SingleResult{},
+		expectedSignals: FileSignals{
+			StringLengths:         valuecounts.New(),
+			IdentifierLengths:     valuecounts.New(),
+			SuspiciousIdentifiers: []SuspiciousIdentifier{},
+			EscapedStrings:        []EscapedString{},
+			Base64Strings:         []string{},
+			EmailAddresses:        []string{},
+			HexStrings:            []string{},
+			IPAddresses:           []string{},
+			URLs:                  []string{},
+		},
+	},
+	{
 		name: "simple 1",
 		parseData: parsing.SingleResult{
 			Identifiers: []token.Identifier{
@@ -111,6 +126,33 @@ var fileSignalsTestCases = []fileSignalsTestCase{
 			URLs:           []string{"https://this.is.a.website.com"},
 		},
 	},
+	{
+		name: "escaped strings",
+		parseData: parsing.SingleResult{
+			StringLiterals: []token.String{
+				{Value: "@ABCD", Raw: "\\100\\101\\102\\103\\104"},
+				{Value: "@ABCD", Raw: "\\x40\\x41\\x42\\x43\\x44"},
+				{Value: "@ABCD", Raw: "\\u0040\\u0041\\u0042\\u0043\\u0044"},
+				{Value: "@ABCD", Raw: "\\U00000040\\U00000041\\U00000042\\U00000043\\U00000044"},
+			},
+		},
+		expectedSignals: FileSignals{
+			StringLengths:         valuecounts.Count([]int{5, 5, 5, 5}),
+			IdentifierLengths:     valuecounts.New(),
+			SuspiciousIdentifiers: []SuspiciousIdentifier{},
+			Base64Strings:         []string{},
+			EmailAddresses:        []string{},
+			HexStrings:            []string{},
+			IPAddresses:           []string{},
+			URLs:                  []string{},
+			EscapedStrings: []EscapedString{
+				{Value: "@ABCD", Raw: "\\100\\101\\102\\103\\104", LevenshteinDist: 25},
+				{Value: "@ABCD", Raw: "\\x40\\x41\\x42\\x43\\x44", LevenshteinDist: 25},
+				{Value: "@ABCD", Raw: "\\u0040\\u0041\\u0042\\u0043\\u0044", LevenshteinDist: 35},
+				{Value: "@ABCD", Raw: "\\U00000040\\U00000041\\U00000042\\U00000043\\U00000044", LevenshteinDist: 55},
+			},
+		},
+	},
 }
 
 func TestComputeSignals(t *testing.T) {
@@ -119,7 +161,7 @@ func TestComputeSignals(t *testing.T) {
 			signals := ComputeFileSignals(test.parseData)
 			if !reflect.DeepEqual(signals, test.expectedSignals) {
 				t.Errorf("actual signals did not match expected\n"+
-					"== want ==\n%v\n== got ==\n%v\n======", test.expectedSignals, signals)
+					"== want ==\n%v\n== got ==\n%#v\n======", test.expectedSignals, signals)
 			}
 		})
 	}

--- a/internal/staticanalysis/task.go
+++ b/internal/staticanalysis/task.go
@@ -14,9 +14,9 @@ const (
 	// source code information from the file.
 	Parsing Task = "parsing"
 
-	// Signals analysis involves using certain rules to detect the presence of
-	// obfuscated code. It depends on the output of the Parsing task, but does not
-	// require reading files directly.
+	// Signals analysis involves using applying certain detection rules to extract
+	// signals of interest from the code. It depends on the output of the Parsing task,
+	// and does not require reading files directly.
 	Signals Task = "signals"
 
 	// All is not a task itself, but represents/'depends on' all other tasks.

--- a/internal/staticanalysis/token/tokens.go
+++ b/internal/staticanalysis/token/tokens.go
@@ -1,6 +1,10 @@
 package token
 
-import "github.com/ossf/package-analysis/internal/staticanalysis/signals/stringentropy"
+import (
+	"github.com/texttheater/golang-levenshtein/levenshtein"
+
+	"github.com/ossf/package-analysis/internal/staticanalysis/signals/stringentropy"
+)
 
 type Identifier struct {
 	Name    string         `json:"name"`
@@ -24,6 +28,12 @@ type String struct {
 // character distribution and sets its Entropy field to the result value
 func (s *String) ComputeEntropy(probs map[rune]float64) {
 	s.Entropy = stringentropy.Calculate(s.Value, probs)
+}
+
+// LevenshteinDist computes the Levenshtein distance between the parsed and raw versions of
+// this literal. A character substitution is treated as deletion and insertion (2 operations).
+func (s *String) LevenshteinDist() int {
+	return levenshtein.DistanceForStrings([]rune(s.Raw), []rune(s.Value), levenshtein.DefaultOptions)
 }
 
 type Int struct {


### PR DESCRIPTION
The `EscapedStrings` struct currently contains only the raw string literal for each detected value. This PR adds the parsed string value to the output struct. 

It also replaces calculation of the Levenshtein distance ratio with the absolute Levenshtein distance between the parsed and raw literals, since the ratio can be computed from the other quantities easily if desired. 

The Levenshtein distance function for string literals is now a method on the `token.String` object rather than a standalone function in the `detections` package