### PR TITLE
Static analysis: unify result struct into single array of file data

### DIFF
--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -30,20 +30,20 @@
     "type": "RECORD",
     "fields": [
       {
-        "name": "basic",
-        "mode": "NULLABLE",
+        "name": "files",
+        "mode": "REPEATED",
         "type": "RECORD",
         "fields": [
           {
-            "name": "files",
-            "mode": "REPEATED",
+            "name": "filename",
+            "mode": "REQUIRED",
+            "type": "STRING"
+          },
+          {
+            "name": "basic",
+            "mode": "NULLABLE",
             "type": "RECORD",
             "fields": [
-              {
-                "name": "filename",
-                "mode": "REQUIRED",
-                "type": "STRING"
-              },
               {
                 "name": "description",
                 "mode": "NULLABLE",
@@ -52,10 +52,10 @@
               {
                 "name": "size",
                 "mode": "NULLABLE",
-                "type": "INTEGER"
+                "type": "INT64"
               },
               {
-                "name": "hash",
+                "name": "sha256",
                 "mode": "NULLABLE",
                 "type": "STRING"
               },
@@ -67,182 +67,29 @@
                   {
                     "name": "value",
                     "mode": "REQUIRED",
-                    "type": "INTEGER"
+                    "type": "INT64"
                   },
                   {
                     "name": "count",
                     "mode": "REQUIRED",
-                    "type": "INTEGER"
+                    "type": "INT64"
                   }
                 ]
               }
             ]
-          }
-        ]
-      },
-      {
-        "name": "parsing",
-        "mode": "REPEATED",
-        "type": "RECORD",
-        "fields": [
-          {
-            "name": "filename",
-            "mode": "REQUIRED",
-            "type": "STRING"
           },
           {
-            "name": "language",
-            "mode": "REQUIRED",
-            "type": "STRING"
-          },
-          {
-            "name": "identifiers",
+            "name": "parsing",
             "mode": "REPEATED",
             "type": "RECORD",
             "fields": [
               {
-                "name": "name",
+                "name": "language",
                 "mode": "REQUIRED",
                 "type": "STRING"
               },
               {
-                "name": "type",
-                "mode": "NULLABLE",
-                "type": "STRING"
-              },
-              {
-                "name": "entropy",
-                "mode": "NULLABLE",
-                "type": "FLOAT64"
-              }
-            ]
-          },
-          {
-            "name": "string_literals",
-            "mode": "REPEATED",
-            "type": "RECORD",
-            "fields": [
-              {
-                "name": "value",
-                "mode": "REQUIRED",
-                "type": "STRING"
-              },
-              {
-                "name": "raw",
-                "mode": "NULLABLE",
-                "type": "STRING"
-              },
-              {
-                "name": "entropy",
-                "mode": "NULLABLE",
-                "type": "FLOAT64"
-              }
-            ]
-          },
-          {
-            "name": "int_literals",
-            "mode": "REPEATED",
-            "type": "RECORD",
-            "fields": [
-              {
-                "name": "value",
-                "mode": "REQUIRED",
-                "type": "INTEGER"
-              },
-              {
-                "name": "raw",
-                "mode": "NULLABLE",
-                "type": "STRING"
-              }
-            ]
-          },
-          {
-            "name": "float_literals",
-            "mode": "REPEATED",
-            "type": "RECORD",
-            "fields": [
-              {
-                "name": "value",
-                "mode": "REQUIRED",
-                "type": "FLOAT64"
-              },
-              {
-                "name": "raw",
-                "mode": "REQUIRED",
-                "type": "STRING"
-              }
-            ]
-          },
-          {
-            "name": "comments",
-            "mode": "REPEATED",
-            "type": "RECORD",
-            "fields": [
-              {
-                "name": "text",
-                "mode": "REQUIRED",
-                "type": "STRING"
-              }
-            ]
-          }
-          ]
-      },
-      {
-        "name": "obfuscation",
-        "mode": "NULLABLE",
-        "type": "RECORD",
-        "fields": [
-          {
-            "name": "excluded_files",
-            "mode": "REPEATED",
-            "type": "STRING"
-          },
-          {
-            "name": "signals",
-            "mode": "REPEATED",
-            "type": "RECORD",
-            "fields": [
-              {
-                "name": "filename",
-                "mode": "REQUIRED",
-                "type": "STRING"
-              },
-              {
-                "name": "identifier_lengths",
-                "mode": "REPEATED",
-                "type": "RECORD",
-                "fields": [
-                  {
-                    "name": "value",
-                    "mode": "REQUIRED",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "name": "count",
-                    "mode": "REQUIRED",
-                    "type": "INTEGER"
-                  }
-                ]
-              },
-              {
-                "name": "string_lengths",
-                "mode": "REPEATED",
-                "type": "RECORD",
-                "fields": [
-                  {
-                    "name": "value",
-                    "mode": "REQUIRED",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "name": "count",
-                    "mode": "REQUIRED",
-                    "type": "INTEGER"
-                  }
-                ]
-              },
-              {
-                "name": "suspicious_identifiers",
+                "name": "identifiers",
                 "mode": "REPEATED",
                 "type": "RECORD",
                 "fields": [
@@ -252,14 +99,19 @@
                     "type": "STRING"
                   },
                   {
-                    "name": "rule",
+                    "name": "type",
                     "mode": "NULLABLE",
                     "type": "STRING"
+                  },
+                  {
+                    "name": "entropy",
+                    "mode": "NULLABLE",
+                    "type": "FLOAT64"
                   }
                 ]
               },
               {
-                "name": "escaped_strings",
+                "name": "string_literals",
                 "mode": "REPEATED",
                 "type": "RECORD",
                 "fields": [
@@ -270,40 +122,183 @@
                   },
                   {
                     "name": "raw",
-                    "mode": "REQUIRED",
+                    "mode": "NULLABLE",
                     "type": "STRING"
                   },
                   {
-                    "name": "levenshtein_dist",
+                    "name": "entropy",
                     "mode": "NULLABLE",
-                    "type": "INTT64"
+                    "type": "FLOAT64"
                   }
                 ]
               },
               {
-                "name": "base64_strings",
+                "name": "int_literals",
+                "mode": "REPEATED",
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "name": "value",
+                    "mode": "REQUIRED",
+                    "type": "INT64"
+                  },
+                  {
+                    "name": "raw",
+                    "mode": "NULLABLE",
+                    "type": "STRING"
+                  }
+                ]
+              },
+              {
+                "name": "float_literals",
+                "mode": "REPEATED",
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "name": "value",
+                    "mode": "REQUIRED",
+                    "type": "FLOAT64"
+                  },
+                  {
+                    "name": "raw",
+                    "mode": "REQUIRED",
+                    "type": "STRING"
+                  }
+                ]
+              },
+              {
+                "name": "comments",
+                "mode": "REPEATED",
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "name": "text",
+                    "mode": "REQUIRED",
+                    "type": "STRING"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "obfuscation",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "excluded_files",
                 "mode": "REPEATED",
                 "type": "STRING"
               },
               {
-                "name": "email_addresses",
+                "name": "signals",
                 "mode": "REPEATED",
-                "type": "STRING"
-              },
-              {
-                "name": "hex_strings",
-                "mode": "REPEATED",
-                "type": "STRING"
-              },
-              {
-                "name": "ip_addresses",
-                "mode": "REPEATED",
-                "type": "STRING"
-              },
-              {
-                "name": "urls",
-                "mode": "REPEATED",
-                "type": "STRING"
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "name": "filename",
+                    "mode": "REQUIRED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "identifier_lengths",
+                    "mode": "REPEATED",
+                    "type": "RECORD",
+                    "fields": [
+                      {
+                        "name": "value",
+                        "mode": "REQUIRED",
+                        "type": "INT64"
+                      },
+                      {
+                        "name": "count",
+                        "mode": "REQUIRED",
+                        "type": "INT64"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "string_lengths",
+                    "mode": "REPEATED",
+                    "type": "RECORD",
+                    "fields": [
+                      {
+                        "name": "value",
+                        "mode": "REQUIRED",
+                        "type": "INT64"
+                      },
+                      {
+                        "name": "count",
+                        "mode": "REQUIRED",
+                        "type": "INT64"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "suspicious_identifiers",
+                    "mode": "REPEATED",
+                    "type": "RECORD",
+                    "fields": [
+                      {
+                        "name": "name",
+                        "mode": "REQUIRED",
+                        "type": "STRING"
+                      },
+                      {
+                        "name": "rule",
+                        "mode": "NULLABLE",
+                        "type": "STRING"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "escaped_strings",
+                    "mode": "REPEATED",
+                    "type": "RECORD",
+                    "fields": [
+                      {
+                        "name": "value",
+                        "mode": "REQUIRED",
+                        "type": "STRING"
+                      },
+                      {
+                        "name": "raw",
+                        "mode": "REQUIRED",
+                        "type": "STRING"
+                      },
+                      {
+                        "name": "levenshtein_dist",
+                        "mode": "NULLABLE",
+                        "type": "INT64"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "base64_strings",
+                    "mode": "REPEATED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "email_addresses",
+                    "mode": "REPEATED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "hex_strings",
+                    "mode": "REPEATED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "ip_addresses",
+                    "mode": "REPEATED",
+                    "type": "STRING"
+                  },
+                  {
+                    "name": "urls",
+                    "mode": "REPEATED",
+                    "type": "STRING"
+                  }
+                ]
               }
             ]
           }

--- a/internal/resultstore/resultstore.go
+++ b/internal/resultstore/resultstore.go
@@ -257,9 +257,9 @@ func (rs *ResultStore) SaveDynamicAnalysis(ctx context.Context, p Pkg, analysis 
 	return rs.saveWithFilename(ctx, p, data, filename)
 }
 
-// SaveStaticAnalysis wraps the analysis object with the result struct and saves it to the bucket
+// SaveStaticAnalysis wraps the results object with the StaticAnalysisRecord struct and saves it to the bucket
 // using saveWithFilename. If filename is empty, a default filename (chosen using DefaultFilename) is used.
-func (rs *ResultStore) SaveStaticAnalysis(ctx context.Context, p Pkg, analysis any, filename string) error {
+func (rs *ResultStore) SaveStaticAnalysis(ctx context.Context, p Pkg, results any, filename string) error {
 	if filename == "" {
 		filename = DefaultFilename(p)
 	}
@@ -270,7 +270,7 @@ func (rs *ResultStore) SaveStaticAnalysis(ctx context.Context, p Pkg, analysis a
 		Name:          p.Name(),
 		Version:       p.Version(),
 		Created:       time.Now().UTC(),
-		Results:       analysis,
+		Results:       results,
 	}
 
 	return rs.saveWithFilename(ctx, p, data, filename)

--- a/internal/staticanalysis/analyze_test.go
+++ b/internal/staticanalysis/analyze_test.go
@@ -1,0 +1,120 @@
+package staticanalysis
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ossf/package-analysis/internal/log"
+	"github.com/ossf/package-analysis/internal/staticanalysis/basicdata"
+	"github.com/ossf/package-analysis/internal/staticanalysis/parsing"
+	"github.com/ossf/package-analysis/internal/staticanalysis/signals"
+	"github.com/ossf/package-analysis/internal/staticanalysis/token"
+	"github.com/ossf/package-analysis/internal/utils/valuecounts"
+)
+
+type testFile struct {
+	filename    string
+	contents    []byte
+	sha256      string
+	description string
+	lineLengths valuecounts.ValueCounts
+}
+
+var helloWorldJs = testFile{
+	filename:    "hi.js",
+	contents:    []byte(`console.log("hi");` + "\n"),
+	sha256:      "2bf8b125d15a71b5fa79fe710cae0db911a71e65891e270bca1d4eb5dd785288",
+	description: "ASCII text",
+	lineLengths: valuecounts.Count([]int{18}),
+}
+
+func makeDesiredResult(files ...testFile) *Result {
+	result := Result{
+		Files: []SingleResult{},
+	}
+	for _, file := range files {
+		result.Files = append(result.Files, SingleResult{
+			Filename: file.filename,
+			Basic: &basicdata.FileData{
+				Description: file.description,
+				Size:        int64(len(file.contents)),
+				SHA256:      file.sha256,
+				LineLengths: file.lineLengths,
+			},
+			Parsing: &parsing.SingleResult{
+				Language:    parsing.JavaScript,
+				Identifiers: []token.Identifier{},
+				StringLiterals: []token.String{
+					{Value: "hi", Raw: `"hi"`, Entropy: math.Log(2.0)},
+				},
+				IntLiterals:   []token.Int{},
+				FloatLiterals: []token.Float{},
+				Comments:      []token.Comment{},
+			},
+			Signals: &signals.FileSignals{
+				IdentifierLengths:     valuecounts.New(),
+				StringLengths:         valuecounts.Count([]int{2}),
+				SuspiciousIdentifiers: []signals.SuspiciousIdentifier{},
+				EscapedStrings:        []signals.EscapedString{},
+				Base64Strings:         []string{},
+				EmailAddresses:        []string{},
+				HexStrings:            []string{},
+				IPAddresses:           []string{},
+				URLs:                  []string{},
+			},
+		})
+	}
+
+	return &result
+}
+
+func TestAnalyzePackageFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []testFile
+		want    *Result
+		wantErr bool
+	}{
+		{
+			name:    "hello JS",
+			files:   []testFile{helloWorldJs},
+			want:    makeDesiredResult(helloWorldJs),
+			wantErr: false,
+		},
+	}
+	parserDir := t.TempDir()
+	jsParserConfig, err := parsing.InitParser(parserDir)
+	if err != nil {
+		t.Errorf("failed to init parser: %v", err)
+		return
+	}
+
+	log.Initialize("")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractDir := t.TempDir()
+			for _, file := range tt.files {
+				extractPath := filepath.Join(extractDir, file.filename)
+				fmt.Printf("writing %s to %s\n", file.filename, extractPath)
+				if err := os.WriteFile(extractPath, file.contents, 0o666); err != nil {
+					t.Errorf("failed to write test file: %v", err)
+					return
+				}
+			}
+			got, err := AnalyzePackageFiles(extractDir, jsParserConfig, AllTasks())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AnalyzePackageFiles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AnalyzePackageFiles() \n"+
+					"------------- got ----------------\n%v\n\n"+
+					"--------------want----------------\n%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/staticanalysis/basicdata/basic_data_test.go
+++ b/internal/staticanalysis/basicdata/basic_data_test.go
@@ -83,7 +83,6 @@ func TestGetBasicData(t *testing.T) {
 
 			wantData := utils.Transform(tt.files, func(f testFile) FileData {
 				return FileData{
-					Filename:    f.filename,
 					Description: f.fileType,
 					Size:        int64(len(f.contents)),
 					SHA256:      f.contentsHash,
@@ -91,9 +90,7 @@ func TestGetBasicData(t *testing.T) {
 				}
 			})
 
-			gotData := got.Files
-
-			if !reflect.DeepEqual(gotData, wantData) {
+			if !reflect.DeepEqual(got, wantData) {
 				t.Errorf("TestGetBasicData() data mismatch:\n"+
 					"== got == \n%v\n== want ==\n%v", got, wantData)
 			}

--- a/internal/staticanalysis/parsing/analyze_test.go
+++ b/internal/staticanalysis/parsing/analyze_test.go
@@ -1,6 +1,7 @@
 package parsing
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -26,6 +27,23 @@ var identifierCharProbs = []map[rune]float64{
 
 var analyzeTestcases = []analyzeTestcase{
 	{
+		name:     "console log hi",
+		jsSource: `console.log("hi");`,
+		expectedData: SingleResult{
+			Language:    JavaScript,
+			Identifiers: []token.Identifier{
+				// Members excluded
+				//{Name: "log", Type: token.Member, Entropy: math.Log(3)},
+			},
+			StringLiterals: []token.String{
+				{Value: "hi", Raw: `"hi"`, Entropy: math.Log(2)},
+			},
+			IntLiterals:   []token.Int{},
+			FloatLiterals: []token.Float{},
+			Comments:      []token.Comment{},
+		},
+	},
+	{
 		name: "simple 1",
 		jsSource: `
 var a = "hello"
@@ -40,6 +58,7 @@ var a = "hello"
 			},
 			IntLiterals:   []token.Int{},
 			FloatLiterals: []token.Float{},
+			Comments:      []token.Comment{},
 		},
 	},
 	{
@@ -73,6 +92,7 @@ function test(a, b = 2) {
 				{Value: 4, Raw: "4"},
 			},
 			FloatLiterals: []token.Float{},
+			Comments:      []token.Comment{},
 		},
 	},
 	{
@@ -84,6 +104,7 @@ function test(a, b = 2) {
 			StringLiterals: []token.String{},
 			IntLiterals:    []token.Int{},
 			FloatLiterals:  []token.Float{},
+			Comments:       []token.Comment{},
 		},
 	},
 }
@@ -101,7 +122,7 @@ func TestAnalyze(t *testing.T) {
 				t.Errorf("%v", err)
 				return
 			}
-			got := result["stdin"][0]
+			got := result["stdin"]
 
 			if got.Language != tt.expectedData.Language {
 				t.Errorf("Filename mismatch: got %s, want %s", got.Language, tt.expectedData.Language)
@@ -118,6 +139,9 @@ func TestAnalyze(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got.FloatLiterals, tt.expectedData.FloatLiterals) {
 				t.Errorf("Float literals mismatch: got %#v, want %v", got.FloatLiterals, tt.expectedData.FloatLiterals)
+			}
+			if !reflect.DeepEqual(got.Comments, tt.expectedData.Comments) {
+				t.Errorf("Comments mismatch: got %#v, want %v", got.Comments, tt.expectedData.Comments)
 			}
 		})
 	}

--- a/internal/staticanalysis/parsing/analyze_test.go
+++ b/internal/staticanalysis/parsing/analyze_test.go
@@ -31,7 +31,6 @@ var analyzeTestcases = []analyzeTestcase{
 var a = "hello"
 	`,
 		expectedData: SingleResult{
-			Filename: "stdin",
 			Language: JavaScript,
 			Identifiers: []token.Identifier{
 				{Name: "a", Type: token.Variable, Entropy: stringentropy.Calculate("a", identifierCharProbs[0])},
@@ -57,7 +56,6 @@ function test(a, b = 2) {
 }
 	`,
 		expectedData: SingleResult{
-			Filename: "stdin",
 			Language: JavaScript,
 			Identifiers: []token.Identifier{
 				{Name: "test", Type: token.Function, Entropy: stringentropy.Calculate("test", identifierCharProbs[1])},
@@ -81,7 +79,6 @@ function test(a, b = 2) {
 		name:     "invalid 1",
 		jsSource: "this is not JavaScript",
 		expectedData: SingleResult{
-			Filename:       "stdin",
 			Language:       NoLanguage,
 			Identifiers:    []token.Identifier{},
 			StringLiterals: []token.String{},
@@ -104,11 +101,8 @@ func TestAnalyze(t *testing.T) {
 				t.Errorf("%v", err)
 				return
 			}
-			got := result[0]
+			got := result["stdin"][0]
 
-			if got.Filename != tt.expectedData.Filename {
-				t.Errorf("Filename mismatch: got %s, want %s", got.Filename, tt.expectedData.Filename)
-			}
 			if got.Language != tt.expectedData.Language {
 				t.Errorf("Filename mismatch: got %s, want %s", got.Language, tt.expectedData.Language)
 			}

--- a/internal/staticanalysis/parsing/result.go
+++ b/internal/staticanalysis/parsing/result.go
@@ -21,12 +21,12 @@ type SingleResult struct {
 
 func (r SingleResult) String() string {
 	parts := []string{
-		fmt.Sprintf("language: %s\n", r.Language),
-		fmt.Sprintf("identifiers\n%v\n", r.Identifiers),
-		fmt.Sprintf("string literals\n%v\n", r.StringLiterals),
-		fmt.Sprintf("integer literals\n%v\n", r.IntLiterals),
-		fmt.Sprintf("float literals\n%v\n", r.FloatLiterals),
-		fmt.Sprintf("comments\n%v\n", r.Comments),
+		fmt.Sprintf("language: %s", r.Language),
+		fmt.Sprintf("identifiers\n%v", r.Identifiers),
+		fmt.Sprintf("string literals\n%v", r.StringLiterals),
+		fmt.Sprintf("integer literals\n%v", r.IntLiterals),
+		fmt.Sprintf("float literals\n%v", r.FloatLiterals),
+		fmt.Sprintf("comments\n%v", r.Comments),
 	}
-	return strings.Join(parts, "\n-------------------\n")
+	return strings.Join(parts, "\n")
 }

--- a/internal/staticanalysis/parsing/result.go
+++ b/internal/staticanalysis/parsing/result.go
@@ -10,7 +10,6 @@ import (
 // SingleResult holds processed information about source code tokens
 // found in a single file by a single language parser
 type SingleResult struct {
-	Filename       string             `json:"filename"`
 	Language       Language           `json:"language"`
 	Identifiers    []token.Identifier `json:"identifiers"`
 	StringLiterals []token.String     `json:"string_literals"`
@@ -22,7 +21,6 @@ type SingleResult struct {
 
 func (r SingleResult) String() string {
 	parts := []string{
-		fmt.Sprintf("filename: %s\n", r.Filename),
 		fmt.Sprintf("language: %s\n", r.Language),
 		fmt.Sprintf("identifiers\n%v\n", r.Identifiers),
 		fmt.Sprintf("string literals\n%v\n", r.StringLiterals),

--- a/internal/staticanalysis/result.go
+++ b/internal/staticanalysis/result.go
@@ -13,26 +13,38 @@ import (
 /*
 Result (staticanalysis.Result) is the top-level data structure that stores all data
 produced by static analysis performed on a package / artifact. Each element
-corresponds to an individual static analysis task (see Task). Note that this data
-is sent across a sandbox boundary, so all nested structs must be JSON serialisable.
+corresponds to an individual static analysis task (see Task).
 */
 type Result struct {
-	// NOTE: the JSON names below should match the values in task.go
-	BasicData *basicdata.PackageData `json:"basic,omitempty"`
-
-	ParsingData []parsing.SingleResult `json:"parsing,omitempty"`
-
-	SignalsData *signals.Result `json:"signals,omitempty"`
+	Files []SingleResult `json:"files"`
 }
 
-func (ar Result) String() string {
-	parsingDataStrings := utils.Transform(ar.ParsingData, func(d parsing.SingleResult) string { return d.String() })
+/*
+SingleResult (staticanalysis.SingleResult) stores all data obtained by static analysis,
+performed on a single file of a package / artifact. Each field corresponds to a different
+analysis task (see Task). All nested structs must be JSON serialisable, so they can be
+sent across the sandbox boundary.
+*/
+type SingleResult struct {
+	// Filename is the relative path to the file within the package
+	Filename string `json:"filename"`
+
+	// NOTE: the JSON names below should match the values in task.go
+
+	Basic   basicdata.FileData     `json:"basic,omitempty"`
+	Parsing []parsing.SingleResult `json:"parsing,omitempty"`
+	Signals signals.FileSignals    `json:"signals,omitempty"`
+}
+
+func (r SingleResult) String() string {
+	parsingDataStrings := utils.Transform(r.Parsing, func(d parsing.SingleResult) string { return d.String() })
 
 	parts := []string{
-		fmt.Sprintf("File basic data\n%v", ar.BasicData),
-		fmt.Sprintf("File parse data\n%s", strings.Join(parsingDataStrings, "\n\n")),
-		fmt.Sprintf("File signals data\n%s", ar.SignalsData),
+		fmt.Sprintf("==== SingleResult: %s ====\n", r.Filename),
+		fmt.Sprintf("== basic data == \n%v", r.Basic),
+		fmt.Sprintf("== parse data ==\n%s", strings.Join(parsingDataStrings, "\n")),
+		fmt.Sprintf("== signals == \n%s", r.Signals),
 	}
 
-	return strings.Join(parts, "\n\n########################\n\n")
+	return strings.Join(parts, "\n\n")
 }

--- a/internal/staticanalysis/result.go
+++ b/internal/staticanalysis/result.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ossf/package-analysis/internal/staticanalysis/basicdata"
 	"github.com/ossf/package-analysis/internal/staticanalysis/parsing"
 	"github.com/ossf/package-analysis/internal/staticanalysis/signals"
-	"github.com/ossf/package-analysis/internal/utils"
 )
 
 /*
@@ -31,18 +30,16 @@ type SingleResult struct {
 
 	// NOTE: the JSON names below should match the values in task.go
 
-	Basic   basicdata.FileData     `json:"basic,omitempty"`
-	Parsing []parsing.SingleResult `json:"parsing,omitempty"`
-	Signals signals.FileSignals    `json:"signals,omitempty"`
+	Basic   *basicdata.FileData   `json:"basic,omitempty"`
+	Parsing *parsing.SingleResult `json:"parsing,omitempty"`
+	Signals *signals.FileSignals  `json:"signals,omitempty"`
 }
 
 func (r SingleResult) String() string {
-	parsingDataStrings := utils.Transform(r.Parsing, func(d parsing.SingleResult) string { return d.String() })
-
 	parts := []string{
 		fmt.Sprintf("==== SingleResult: %s ====\n", r.Filename),
 		fmt.Sprintf("== basic data == \n%v", r.Basic),
-		fmt.Sprintf("== parse data ==\n%s", strings.Join(parsingDataStrings, "\n")),
+		fmt.Sprintf("== parse data ==\n%v", r.Parsing),
 		fmt.Sprintf("== signals == \n%s", r.Signals),
 	}
 

--- a/internal/staticanalysis/signals/analyze.go
+++ b/internal/staticanalysis/signals/analyze.go
@@ -1,23 +1,72 @@
 package signals
 
-import "github.com/ossf/package-analysis/internal/staticanalysis/parsing"
+import (
+	"unicode/utf8"
 
-/*
-Analyze performs signals analysis for a package, operating on the data
-obtained from parsing each file in the package.
-If Language is empty (== NoLanguage), it means that the file could not be
-parsed with any parser.
-*/
-func Analyze(parseData []parsing.SingleResult) Result {
-	result := Result{
-		Files: []FileSignals{},
+	"github.com/ossf/package-analysis/internal/staticanalysis/parsing"
+	"github.com/ossf/package-analysis/internal/staticanalysis/signals/detections"
+	"github.com/ossf/package-analysis/internal/staticanalysis/token"
+	"github.com/ossf/package-analysis/internal/utils"
+	"github.com/ossf/package-analysis/internal/utils/valuecounts"
+)
+
+// countLengths returns a map containing the aggregated lengths
+// of each of the strings in the input list
+func countLengths(symbols []string) valuecounts.ValueCounts {
+	lengths := make([]int, 0, len(symbols))
+	for _, s := range symbols {
+		lengths = append(lengths, utf8.RuneCountInString(s))
 	}
 
-	for _, d := range parseData {
-		signalsData := ComputeFileSignals(d)
-		signalsData.Filename = d.Filename
-		result.Files = append(result.Files, signalsData)
+	return valuecounts.Count(lengths)
+}
+
+// AnalyzeSingle collects signals of interest for a file in a package, operating on a single
+// parsing result (i.e. from one language parser). It returns a FileSignals object, containing
+// information that may be useful to determine whether the file contains malicious code.
+func AnalyzeSingle(parseData parsing.SingleResult) FileSignals {
+	identifierNames := utils.Transform(parseData.Identifiers, func(i token.Identifier) string { return i.Name })
+	stringLiterals := utils.Transform(parseData.StringLiterals, func(s token.String) string { return s.Value })
+
+	identifierLengths := countLengths(identifierNames)
+	stringLengths := countLengths(stringLiterals)
+
+	signals := FileSignals{
+		IdentifierLengths:     identifierLengths,
+		StringLengths:         stringLengths,
+		Base64Strings:         []string{},
+		HexStrings:            []string{},
+		EscapedStrings:        []EscapedString{},
+		SuspiciousIdentifiers: []SuspiciousIdentifier{},
+		URLs:                  []string{},
+		IPAddresses:           []string{},
+		EmailAddresses:        []string{},
 	}
 
-	return result
+	for _, name := range identifierNames {
+		for rule, pattern := range detections.SuspiciousIdentifierPatterns {
+			if pattern.MatchString(name) {
+				signals.SuspiciousIdentifiers = append(signals.SuspiciousIdentifiers, SuspiciousIdentifier{name, rule})
+				break // don't bother searching for multiple matching rules
+			}
+		}
+	}
+
+	for _, sl := range parseData.StringLiterals {
+		signals.Base64Strings = append(signals.Base64Strings, detections.FindBase64Substrings(sl.Value)...)
+		signals.HexStrings = append(signals.HexStrings, detections.FindHexSubstrings(sl.Value)...)
+		signals.URLs = append(signals.URLs, detections.FindURLs(sl.Value)...)
+		signals.IPAddresses = append(signals.IPAddresses, detections.FindIPAddresses(sl.Value)...)
+		signals.EmailAddresses = append(signals.EmailAddresses, detections.FindEmailAddresses(sl.Value)...)
+		if detections.IsHighlyEscaped(sl, 8, 0.25) {
+			escapedString := EscapedString{
+				Value:           sl.Value,
+				Raw:             sl.Raw,
+				LevenshteinDist: sl.LevenshteinDist(),
+			}
+			signals.EscapedStrings = append(signals.EscapedStrings, escapedString)
+		}
+	}
+
+	return signals
 }

--- a/internal/staticanalysis/signals/file_signals.go
+++ b/internal/staticanalysis/signals/file_signals.go
@@ -3,20 +3,12 @@ package signals
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
-	"github.com/ossf/package-analysis/internal/staticanalysis/parsing"
-	"github.com/ossf/package-analysis/internal/staticanalysis/signals/detections"
-	"github.com/ossf/package-analysis/internal/staticanalysis/token"
-	"github.com/ossf/package-analysis/internal/utils"
 	"github.com/ossf/package-analysis/internal/utils/valuecounts"
 )
 
 // FileSignals holds information related to the presence of obfuscated code in a single file.
 type FileSignals struct {
-	// Filename is the path in the package
-	Filename string `json:"filename"`
-
 	// The following two variables respectively record how many string literals
 	// and identifiers in the file have a given length. The absence of a count
 	// for a particular lengths means that there were no symbols of that length
@@ -54,7 +46,6 @@ type FileSignals struct {
 
 func (s FileSignals) String() string {
 	parts := []string{
-		fmt.Sprintf("filename: %s", s.Filename),
 		fmt.Sprintf("identifier length counts: %v", s.IdentifierLengths),
 		fmt.Sprintf("string length counts: %v", s.StringLengths),
 
@@ -82,64 +73,4 @@ type EscapedString struct {
 type SuspiciousIdentifier struct {
 	Name string `json:"name"`
 	Rule string `json:"rule"`
-}
-
-// countLengths returns a map containing the aggregated lengths
-// of each of the strings in the input list
-func countLengths(symbols []string) valuecounts.ValueCounts {
-	lengths := make([]int, 0, len(symbols))
-	for _, s := range symbols {
-		lengths = append(lengths, utf8.RuneCountInString(s))
-	}
-
-	return valuecounts.Count(lengths)
-}
-
-// ComputeFileSignals creates a FileSignals object based on the parsing data obtained from
-// a given file. These signals may be useful to determine whether the code is obfuscated.
-func ComputeFileSignals(parseData parsing.SingleResult) FileSignals {
-	identifierNames := utils.Transform(parseData.Identifiers, func(i token.Identifier) string { return i.Name })
-	stringLiterals := utils.Transform(parseData.StringLiterals, func(s token.String) string { return s.Value })
-
-	identifierLengths := countLengths(identifierNames)
-	stringLengths := countLengths(stringLiterals)
-
-	signals := FileSignals{
-		IdentifierLengths:     identifierLengths,
-		StringLengths:         stringLengths,
-		Base64Strings:         []string{},
-		HexStrings:            []string{},
-		EscapedStrings:        []EscapedString{},
-		SuspiciousIdentifiers: []SuspiciousIdentifier{},
-		URLs:                  []string{},
-		IPAddresses:           []string{},
-		EmailAddresses:        []string{},
-	}
-
-	for _, name := range identifierNames {
-		for rule, pattern := range detections.SuspiciousIdentifierPatterns {
-			if pattern.MatchString(name) {
-				signals.SuspiciousIdentifiers = append(signals.SuspiciousIdentifiers, SuspiciousIdentifier{name, rule})
-				break // don't bother searching for multiple matching rules
-			}
-		}
-	}
-
-	for _, sl := range parseData.StringLiterals {
-		signals.Base64Strings = append(signals.Base64Strings, detections.FindBase64Substrings(sl.Value)...)
-		signals.HexStrings = append(signals.HexStrings, detections.FindHexSubstrings(sl.Value)...)
-		signals.URLs = append(signals.URLs, detections.FindURLs(sl.Value)...)
-		signals.IPAddresses = append(signals.IPAddresses, detections.FindIPAddresses(sl.Value)...)
-		signals.EmailAddresses = append(signals.EmailAddresses, detections.FindEmailAddresses(sl.Value)...)
-		if detections.IsHighlyEscaped(sl, 8, 0.25) {
-			escapedString := EscapedString{
-				Value:           sl.Value,
-				Raw:             sl.Raw,
-				LevenshteinDist: sl.LevenshteinDist(),
-			}
-			signals.EscapedStrings = append(signals.EscapedStrings, escapedString)
-		}
-	}
-
-	return signals
 }

--- a/internal/staticanalysis/signals/file_signals_test.go
+++ b/internal/staticanalysis/signals/file_signals_test.go
@@ -158,7 +158,7 @@ var fileSignalsTestCases = []fileSignalsTestCase{
 func TestComputeSignals(t *testing.T) {
 	for _, test := range fileSignalsTestCases {
 		t.Run(test.name, func(t *testing.T) {
-			signals := ComputeFileSignals(test.parseData)
+			signals := AnalyzeSingle(test.parseData)
 			if !reflect.DeepEqual(signals, test.expectedSignals) {
 				t.Errorf("actual signals did not match expected\n"+
 					"== want ==\n%v\n== got ==\n%#v\n======", test.expectedSignals, signals)

--- a/internal/staticanalysis/signals/result.go
+++ b/internal/staticanalysis/signals/result.go
@@ -1,7 +1,0 @@
-package signals
-
-// Result holds all data produced by signals analysis (see Analyze() in analyze.go).
-type Result struct {
-	// Files contains a signals.FileSignals object that is useful for detecting suspicious files.
-	Files []FileSignals `json:"files"`
-}

--- a/internal/staticanalysis/task.go
+++ b/internal/staticanalysis/task.go
@@ -27,7 +27,6 @@ var allTasks = []Task{
 	Basic,
 	Parsing,
 	Signals,
-	All,
 }
 
 func AllTasks() []Task {


### PR DESCRIPTION
This is a significant refactor such that static analysis results now consist of a single array of structs, where each struct contains all the static analysis information for that file (basic data, parsing, signals extracted)

Currently, each distinct static analysis task has a separate field in the top-level result struct, each with a separate list of structs containing filenames (which theoretically should all be identical across the structs for each task) and the other data obtained for that file. This makes the data schema unnecessarily complicated, and would make it harder to do data analysis because data from different tasks has to be joined by filename.

The top-level result struct now looks like
```go
type Result struct {
	Files []SingleResult `json:"files"`
}

type SingleResult struct {
	Filename string `json:"filename"`

	Basic   *basicdata.FileData   `json:"basic,omitempty"`
	Parsing *parsing.SingleResult `json:"parsing,omitempty"`
	Signals *signals.FileSignals  `json:"signals,omitempty"`
}
```

This PR also adds a unit test for the top level analysis function, as a high-level check that data is plumbed through correctly at the top level before being serialised and sent across the sandbox boundary.

Finally, the `signals.ComputeFileSignals` function is renamed to `signals.AnalyzeSingle` and moved to `internal/staticanalysis/signals/analyze.go`