### PR TITLE
clean up dependabot config and check for GH actions updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,22 +3,17 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: "daily"
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/function/loader"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gomod
-  directory: "/sandboxes/staticanalysis"
-  schedule:
-    interval: daily
+    interval: "daily"
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   groups:
     actions-minor-updates:
       update-types:


### PR DESCRIPTION
1. remove obsolete section for (now removed) static analysis gomod
2. check github actions updates weekly which allows for grouped PRs
3. add quotes to all time strings