### PR TITLE
don't upload static analysis results when there is no data

### DIFF
--- a/internal/worker/save_data.go
+++ b/internal/worker/save_data.go
@@ -82,6 +82,9 @@ func saveExecutionLog(ctx context.Context, pkg *pkgmanager.Pkg, dest *ResultStor
 func SaveStaticAnalysisData(ctx context.Context, pkg *pkgmanager.Pkg, dest *ResultStores, data analysisrun.StaticAnalysisResults) error {
 	if dest.StaticAnalysis == nil {
 		return nil
+	} else if len(data) == 0 {
+		slog.WarnContext(ctx, "static analysis data is empty")
+		return nil
 	}
 
 	if err := dest.StaticAnalysis.SaveStaticAnalysis(ctx, pkg, data, ""); err != nil {

--- a/sandboxes/staticanalysis/staticanalyze.go
+++ b/sandboxes/staticanalysis/staticanalyze.go
@@ -162,8 +162,7 @@ func run() (err error) {
 		}
 	}
 
-	err = manager.ExtractArchive(archivePath, workDirs.extractDir)
-	if err != nil {
+	if err := manager.ExtractArchive(archivePath, workDirs.extractDir); err != nil {
 		return fmt.Errorf("archive extraction failed: %w", err)
 	}
 


### PR DESCRIPTION
and log a warning