### PR TITLE
Handle missing PyPI packages properly as well.

### DIFF
--- a/internal/pkgmanager/pypi.go
+++ b/internal/pkgmanager/pypi.go
@@ -73,8 +73,9 @@ func getPyPIArchiveURL(pkgName, version string) (string, error) {
 			return url.URL, nil
 		}
 	}
-	// can't find source tarball
-	return "", fmt.Errorf("source tarball not found for %s, version %s", pkgName, version)
+
+	// Return an empty string and no error if we can't find an archive URL.
+	return "", nil
 }
 
 var pypiPkgManager = PkgManager{


### PR DESCRIPTION
This change returns a nil error if no URL is found for an artifact.

This conforms to the same behavior as Packagist, and causes the manager to return a `ErrNoArchiveURL` which is handled more gracefully.