### PR TITLE
Add `dnsutils` to dynamic analysis image + remove extra update/upgrades

### DIFF
--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
 	build-essential \
 	cmake \
 	clang \
+	dnsutils \
 	golang \
 	iproute2 \
 	iputils-ping \
@@ -66,10 +67,7 @@ RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 # PHP setup
 #
 WORKDIR /setup/php
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
-	php \
-	php-zip \
-	php-gd
+RUN apt-get install -y --no-install-recommends php php-zip php-gd
 
 # Install Composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
@@ -83,7 +81,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
 #
 # Installs node and npm via the nodejs package, pulled from nodesource.com configured above.
 WORKDIR /setup/node
-RUN apt-get update && apt-get install -y --no-install-recommends nodejs
+RUN apt-get install -y --no-install-recommends nodejs
 
 COPY bowerrc /app/.bowerrc
 
@@ -92,9 +90,7 @@ COPY bowerrc /app/.bowerrc
 # Python setup
 #
 WORKDIR /setup/python
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
-	python3 \
-	python3-pip
+RUN apt-get install -y --no-install-recommends python3 python3-pip
 
 # Some Python packages expect certain dependencies to already be installed
 COPY pypi-packages.txt ./
@@ -105,16 +101,13 @@ RUN pip install --require-hashes --requirement pypi-packages.txt
 # Rubygems setup
 #
 WORKDIR /setup/ruby
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
-	ruby \
-	ruby-rubygems
+RUN apt-get install -y --no-install-recommends ruby ruby-rubygems
 
 #
 # Rust setup
 #
 WORKDIR /setup/rust
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
-	rust-all
+RUN apt-get install -y --no-install-recommends rust-all
 
 
 WORKDIR /app


### PR DESCRIPTION
`dnsutils` adds the `nslookup` and `dig` commands, which can be used by malicious packages to exfil data.

The removal of `apt update` and `apt upgrade` helps speed up the docker image building by approx 1 minute (on my workstation)