### PR TITLE
Remove result_bucket_override support.

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -122,16 +122,10 @@ func handleMessage(ctx context.Context, msg *pubsub.Message, packagesBucket *blo
 	version := msg.Metadata["version"]
 	remotePkgPath := msg.Metadata["package_path"]
 
-	resultsBucketOverride := msg.Metadata["results_bucket_override"]
-	if resultsBucketOverride != "" {
-		resultStores.DynamicAnalysis = resultstore.New(resultsBucketOverride, resultstore.ConstructPath())
-	}
-
 	ctx = log.ContextWithAttrs(ctx, slog.String("version", version))
 
 	slog.InfoContext(ctx, "Got request",
 		"package_path", remotePkgPath,
-		"results_bucket_override", resultsBucketOverride,
 	)
 
 	localPkgPath := ""

--- a/tools/analysis/analysis_runner.py
+++ b/tools/analysis/analysis_runner.py
@@ -93,9 +93,6 @@ def _request(name, ecosystem, version, local_file=None, results_bucket=None):
     uploaded_path = _upload_file(local_file)
     attributes.append('package_path=' + uploaded_path)
 
-  if results_bucket:
-    attributes.append('results_bucket_override=' + results_bucket)
-
   print('Requesting analysis with', attributes)
   topic = _TOPIC[_TOPIC.find('://') + 3:]
   subprocess.run(
@@ -119,8 +116,6 @@ def main():
       '-a', '--all', default=False,
       action=argparse.BooleanOptionalAction,
       help='Use all publised versions for the package')
-  parser.add_argument(
-      '-b', '--results', help='Results bucket (overrides default).')
 
   args = parser.parse_args()
 


### PR DESCRIPTION
The feature was never used, and only supported dynamic analysis results. Newer bucket output never enabled override support.