### PR TITLE
static analysis: rename "description" field to "detected_type"

### DIFF
--- a/function/loader/static-analysis-schema.json
+++ b/function/loader/static-analysis-schema.json
@@ -45,7 +45,7 @@
             "type": "RECORD",
             "fields": [
               {
-                "name": "description",
+                "name": "detected_type",
                 "mode": "NULLABLE",
                 "type": "STRING"
               },

--- a/internal/staticanalysis/analyze_test.go
+++ b/internal/staticanalysis/analyze_test.go
@@ -41,10 +41,10 @@ func makeDesiredResult(files ...testFile) *Result {
 		result.Files = append(result.Files, SingleResult{
 			Filename: file.filename,
 			Basic: &basicdata.FileData{
-				Description: file.description,
-				Size:        int64(len(file.contents)),
-				SHA256:      file.sha256,
-				LineLengths: file.lineLengths,
+				DetectedType: file.description,
+				Size:         int64(len(file.contents)),
+				SHA256:       file.sha256,
+				LineLengths:  file.lineLengths,
 			},
 			Parsing: &parsing.SingleResult{
 				Language:    parsing.JavaScript,

--- a/internal/staticanalysis/basicdata/basic_data_test.go
+++ b/internal/staticanalysis/basicdata/basic_data_test.go
@@ -78,16 +78,16 @@ func TestGetBasicData(t *testing.T) {
 
 			got, err := Analyze(context.Background(), paths, getArchivePath)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("describeFiles() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("detectFileTypes() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			wantData := utils.Transform(tt.files, func(f testFile) FileData {
 				return FileData{
-					Description: f.fileType,
-					Size:        int64(len(f.contents)),
-					SHA256:      f.contentsHash,
-					LineLengths: f.lineLengths,
+					DetectedType: f.fileType,
+					Size:         int64(len(f.contents)),
+					SHA256:       f.contentsHash,
+					LineLengths:  f.lineLengths,
 				}
 			})
 

--- a/internal/staticanalysis/basicdata/describe_files.go
+++ b/internal/staticanalysis/basicdata/describe_files.go
@@ -27,7 +27,7 @@ func (h fileCmdArgsHandler) ReadStdinArg() []string {
 	return h.FileListArg("-")
 }
 
-func describeFiles(ctx context.Context, paths []string) ([]string, error) {
+func detectFileTypes(ctx context.Context, paths []string) ([]string, error) {
 	workingDir, err := os.MkdirTemp("", "package-analysis-basic-data-*")
 	if err != nil {
 		return nil, fmt.Errorf("error creating temp file: %w", err)


### PR DESCRIPTION
after some discussion around naming of this field, "detected_type" came out to be a more descriptive name than "description" without misusing the term "magic" or creating ambiguity using just "type"