### PR TITLE
add BigQuery loader function for static analysis

### DIFF
--- a/function/loader/load.go
+++ b/function/loader/load.go
@@ -55,3 +55,40 @@ func Load(ctx context.Context, m PubSubMessage) error {
 	log.Printf("Job created: %s", job.ID())
 	return nil
 }
+
+func LoadStaticAnalysis(ctx context.Context, m PubSubMessage) error {
+	project := os.Getenv("GCP_PROJECT")
+	bucket := os.Getenv("OSSF_MALWARE_STATIC_ANALYSIS_RESULTS")
+
+	bq, err := bigquery.NewClient(ctx, project)
+	if err != nil {
+		log.Panicf("Failed to create BigQuery client: %v", err)
+	}
+	defer bq.Close()
+
+	schema, err := bigquery.SchemaFromJSON(staticAnalysisSchemaJSON)
+	if err != nil {
+		log.Panicf("Failed to decode schema: %v", err)
+	}
+
+	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))
+	gcsRef.Schema = schema
+	gcsRef.SourceFormat = bigquery.JSON
+	gcsRef.MaxBadRecords = 10000
+
+	dataset := bq.Dataset("packages")
+	loader := dataset.Table("staticanalysis").LoaderFrom(gcsRef)
+	loader.WriteDisposition = bigquery.WriteTruncate
+	loader.TimePartitioning = &bigquery.TimePartitioning{
+		Type:  bigquery.DayPartitioningType,
+		Field: "created",
+	}
+
+	job, err := loader.Run(ctx)
+	if err != nil {
+		log.Panicf("Failed to create load job: %v", err)
+	}
+
+	log.Printf("Job created: %s", job.ID())
+	return nil
+}

--- a/function/loader/load.go
+++ b/function/loader/load.go
@@ -70,7 +70,6 @@ func LoadStaticAnalysis(ctx context.Context, m PubSubMessage) error {
 	schema, err := bigquery.SchemaFromJSON(staticAnalysisSchemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to decode schema: %w", err)
-
 	}
 
 	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))


### PR DESCRIPTION
This is the final part of the static analysis data pipeline. Fixes #703 

I made the new static analysis loader function very similar to the existing dynamic analysis loader function, but kept it as a separate function rather than combining the two, so they can be debugged / modified separately.