### PR TITLE
update dynamic analysis Load function

### DIFF
--- a/function/loader/load.go
+++ b/function/loader/load.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"os"
 
 	"cloud.google.com/go/bigquery"
@@ -20,71 +19,7 @@ type PubSubMessage struct {
 	Data []byte `json:"data"`
 }
 
-func Load(ctx context.Context, m PubSubMessage) error {
-	project := os.Getenv("GCP_PROJECT")
-	bucket := os.Getenv("OSSF_MALWARE_ANALYSIS_RESULTS")
-
-	bq, err := bigquery.NewClient(ctx, project)
-	if err != nil {
-		log.Panicf("Failed to create bq client: %v", err)
-	}
-
-	schema, err := bigquery.SchemaFromJSON(dynamicAnalysisSchemaJSON)
-	if err != nil {
-		log.Panicf("Failed to decode schema: %v", err)
-	}
-
-	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))
-	gcsRef.Schema = schema
-	gcsRef.SourceFormat = bigquery.JSON
-	gcsRef.MaxBadRecords = 10000
-
-	dataset := bq.Dataset("packages")
-	loader := dataset.Table("analysis").LoaderFrom(gcsRef)
-	loader.WriteDisposition = bigquery.WriteTruncate
-	loader.TimePartitioning = &bigquery.TimePartitioning{
-		Type:  bigquery.DayPartitioningType,
-		Field: "CreatedTimestamp",
-	}
-
-	job, err := loader.Run(ctx)
-	if err != nil {
-		log.Panicf("Failed to create load job: %v", err)
-	}
-
-	log.Printf("Job created: %s", job.ID())
-	return nil
-}
-
-func LoadStaticAnalysis(ctx context.Context, m PubSubMessage) error {
-	project := os.Getenv("GCP_PROJECT")
-	bucket := os.Getenv("OSSF_MALWARE_STATIC_ANALYSIS_RESULTS")
-
-	bq, err := bigquery.NewClient(ctx, project)
-	if err != nil {
-		return fmt.Errorf("failed to create BigQuery client: %w", err)
-
-	}
-	defer bq.Close()
-
-	schema, err := bigquery.SchemaFromJSON(staticAnalysisSchemaJSON)
-	if err != nil {
-		return fmt.Errorf("failed to decode schema: %w", err)
-	}
-
-	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))
-	gcsRef.Schema = schema
-	gcsRef.SourceFormat = bigquery.JSON
-	gcsRef.MaxBadRecords = 10000
-
-	dataset := bq.Dataset("packages")
-	loader := dataset.Table("staticanalysis").LoaderFrom(gcsRef)
-	loader.WriteDisposition = bigquery.WriteTruncate
-	loader.TimePartitioning = &bigquery.TimePartitioning{
-		Type:  bigquery.DayPartitioningType,
-		Field: "created",
-	}
-
+func runAndWaitForJob(ctx context.Context, loader *bigquery.Loader) error {
 	job, err := loader.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create load job: %v", err)
@@ -107,4 +42,66 @@ func LoadStaticAnalysis(ctx context.Context, m PubSubMessage) error {
 	}
 
 	return nil
+}
+
+func Load(ctx context.Context, m PubSubMessage) error {
+	project := os.Getenv("GCP_PROJECT")
+	bucket := os.Getenv("OSSF_MALWARE_ANALYSIS_RESULTS")
+
+	bq, err := bigquery.NewClient(ctx, project)
+	if err != nil {
+		return fmt.Errorf("failed to create BigQuery client: %w", err)
+	}
+	defer bq.Close()
+
+	schema, err := bigquery.SchemaFromJSON(dynamicAnalysisSchemaJSON)
+	if err != nil {
+		return fmt.Errorf("failed to decode schema: %w", err)
+	}
+
+	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))
+	gcsRef.Schema = schema
+	gcsRef.SourceFormat = bigquery.JSON
+	gcsRef.MaxBadRecords = 10000
+
+	dataset := bq.Dataset("packages")
+	loader := dataset.Table("analysis").LoaderFrom(gcsRef)
+	loader.WriteDisposition = bigquery.WriteTruncate
+	loader.TimePartitioning = &bigquery.TimePartitioning{
+		Type:  bigquery.DayPartitioningType,
+		Field: "CreatedTimestamp",
+	}
+
+	return runAndWaitForJob(ctx, loader)
+}
+
+func LoadStaticAnalysis(ctx context.Context, m PubSubMessage) error {
+	project := os.Getenv("GCP_PROJECT")
+	bucket := os.Getenv("OSSF_MALWARE_STATIC_ANALYSIS_RESULTS")
+
+	bq, err := bigquery.NewClient(ctx, project)
+	if err != nil {
+		return fmt.Errorf("failed to create BigQuery client: %w", err)
+	}
+	defer bq.Close()
+
+	schema, err := bigquery.SchemaFromJSON(staticAnalysisSchemaJSON)
+	if err != nil {
+		return fmt.Errorf("failed to decode schema: %w", err)
+	}
+
+	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/*.json", bucket))
+	gcsRef.Schema = schema
+	gcsRef.SourceFormat = bigquery.JSON
+	gcsRef.MaxBadRecords = 10000
+
+	dataset := bq.Dataset("packages")
+	loader := dataset.Table("staticanalysis").LoaderFrom(gcsRef)
+	loader.WriteDisposition = bigquery.WriteTruncate
+	loader.TimePartitioning = &bigquery.TimePartitioning{
+		Type:  bigquery.DayPartitioningType,
+		Field: "created",
+	}
+
+	return runAndWaitForJob(ctx, loader)
 }


### PR DESCRIPTION
Make the dynamic analysis `Load` function code consistent with the new `LoadStaticAnalysis` function 
- return errors instead of panicking
- reuse job waiting logic from `LoadStaticAnalysis()`
- add `bigquery.Close()` call