### PR TITLE
add explicit go setup step for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+    - name: setup-go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        go-version: '1.21.0'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4


### PR DESCRIPTION
The CodeQL action is failing because of an outdated Go version.

I believe the issue is the same as in https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087, so this PR adds the same fix, which is to add an explicit Go setup step with the correct version (1.21)