### PR TITLE
add alias of scanned vulnerability

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,7 @@
 [[IgnoredVulns]]
 id = "CVE-2020-8911"
 reason = "Indirect dependency, vulnerable function is probably not used and we can't do much about it anyway"
+
+[[IgnoredVulns]]
+id = "GO-2022-0646"
+reason = "alias of CVE-2020-8911"


### PR DESCRIPTION
Required to silence OSV scanner warnings until https://github.com/google/osv-scanner/issues/634 is fixed