### PR TITLE
strace parsing: fix regex issue when unlink syscall does not have path

### DIFF
--- a/internal/strace/strace.go
+++ b/internal/strace/strace.go
@@ -45,7 +45,7 @@ var (
 	socketPattern = regexp.MustCompile(`{Family: ([^,]+), (Addr: ([^,]*), Port: ([0-9]+)|[^}]+)}`)
 
 	// 0x7fe003272980 /tmp/jpu6po61
-	unlinkPatten = regexp.MustCompile(`0x[a-f\d]+ ([^)]+)`)
+	unlinkPatten = regexp.MustCompile(`0x[a-f\d]+ ([^)]+)?`)
 
 	// unlinkat(0x4 /tmp/pip-pip-egg-info-ng4_5gp_/temps.egg-info, 0x7fe0031c9a10 top_level.txt, 0x0)
 	// unlinkat(AT_FDCWD /app, 0x5569a7e83380 /app/vendor/composer/e06632ca, 0x200)


### PR DESCRIPTION
The unlink parsing regex did not support cases where unlink fails due to a nonexisting path, and so the strace log line had a missing path:

```
[ 23: 23] cmake X unlink(0x7f234e5bd500 ) = 0 (0x0) errno=2 (no such file or directory) (667ns)
```

Issue highlighted by `roboflex-visualization` package on pypi