### PR TITLE
Bump Go version to 1.21.5 and use version specified in go.mod in Github Actions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,7 +19,7 @@ jobs:
     - name: setup-go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21.0'
+        go-version-file: 'go.mod'
 
     - name: Enable docker experimental
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21.0'
+        go-version-file: 'go.mod'
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - run: go build -o scheduler cmd/scheduler/main.go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
     - name: setup-go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21.0'
+        go-version-file: 'go.mod'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21.0'
+        go-version-file: 'go.mod'
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
         node-version: 18
@@ -28,6 +28,6 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21.0'
+        go-version-file: 'go.mod'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0

--- a/function/loader/go.mod
+++ b/function/loader/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/package-analysis/loader
 
-go 1.21
+go 1.21.5
 
 require cloud.google.com/go/bigquery v1.57.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/package-analysis
 
-go 1.21
+go 1.21.5
 
 require (
 	cloud.google.com/go/pubsub v1.33.0


### PR DESCRIPTION
Bumping to v1.21.5 resolves some security vulnerabilities found by OSV scanner.

Rather than duplicating the go version in all the Github Actions that use `setup-go`, just point them to look in the main `go.mod` file.