### PR TITLE
Disable the currently failing crates.io test until it is fixed.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run tests
-      run: go test -v ./...
+      run: go test -v -skip "TestDownload/crates.io_rand_valid_version" ./...
   run-linter:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This allows the PRs to keep flowing.

#1015