### PR TITLE
Add user-agents to http requests sent by Package Analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         go-version: '1.21.0'
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
-    - run: go build -o scheduler cmd/scheduler/main.go
-    - run: go build -o worker cmd/worker/main.go
-    - run: go build -o analyze cmd/analyze/main.go
+    - run: go build -o scheduler ./cmd/scheduler
+    - run: go build -o worker ./cmd/worker
+    - run: go build -o analyze ./cmd/analyze
     - run: go build -o loader load.go
       working-directory: function/loader
     - run: go build -o staticanalyze staticanalyze.go

--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -8,7 +8,7 @@ COPY ./go.sum ./
 RUN go mod download
 
 COPY . ./
-RUN go build -o analyze cmd/analyze/main.go && go build -o worker cmd/worker/main.go
+RUN go build -o analyze ./cmd/analyze && go build -o worker ./cmd/worker
 
 FROM ubuntu:22.04@sha256:42ba2dfce475de1113d55602d40af18415897167d47c2045ec7b6d9746ff148f
 

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/ossf/package-analysis/internal/resultstore"
 	"github.com/ossf/package-analysis/internal/sandbox"
 	"github.com/ossf/package-analysis/internal/staticanalysis"
+	"github.com/ossf/package-analysis/internal/useragent"
 	"github.com/ossf/package-analysis/internal/utils"
 	"github.com/ossf/package-analysis/internal/worker"
 	"github.com/ossf/package-analysis/pkg/api/pkgecosystem"
@@ -185,6 +187,8 @@ func run() error {
 
 	analysisMode.InitFlag()
 	flag.Parse()
+
+	http.DefaultTransport = useragent.DefaultRoundTripper(http.DefaultTransport, "")
 
 	if err := featureflags.Update(*features); err != nil {
 		return usageError{err}

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/package-url/packageurl-go"
 
+	"github.com/ossf/package-analysis/internal/useragent"
 	"github.com/ossf/package-analysis/internal/worker"
 )
 
@@ -85,6 +87,8 @@ func processFileLine(text string) error {
 
 func run() error {
 	flag.Parse()
+
+	http.DefaultTransport = useragent.DefaultRoundTripper(http.DefaultTransport, "")
 
 	if *purlFilePath == "" {
 		return newCmdError("Please specify packages to download using -f <file>")

--- a/cmd/worker/config.go
+++ b/cmd/worker/config.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/ossf/package-analysis/internal/resultstore"
+	"github.com/ossf/package-analysis/internal/worker"
+)
+
+// resultBucketPaths holds bucket paths for the different types of results.
+type resultBucketPaths struct {
+	analyzedPkg     string
+	dynamicAnalysis string
+	executionLog    string
+	fileWrites      string
+	staticAnalysis  string
+}
+
+type sandboxImageSpec struct {
+	tag    string
+	noPull bool
+}
+
+type config struct {
+	imageSpec sandboxImageSpec
+
+	resultStores *worker.ResultStores
+
+	subURL               string
+	packagesBucket       string
+	notificationTopicURL string
+
+	userAgentExtra string
+}
+
+func (c *config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("subscription", c.subURL),
+		slog.String("package_bucket", c.packagesBucket),
+		slog.String("dynamic_results_store", c.resultStores.DynamicAnalysis.String()),
+		slog.String("static_results_store", c.resultStores.StaticAnalysis.String()),
+		slog.String("file_write_results_store", c.resultStores.FileWrites.String()),
+		slog.String("analyzed_packages_store", c.resultStores.AnalyzedPackage.String()),
+		slog.String("execution_log_store", c.resultStores.ExecutionLog.String()),
+		slog.String("image_tag", c.imageSpec.tag),
+		slog.Bool("image_nopull", c.imageSpec.noPull),
+		slog.String("topic_notification", c.notificationTopicURL),
+		slog.String("user_agent_extra", c.userAgentExtra),
+	)
+}
+
+func resultStoreForEnv(key string) *resultstore.ResultStore {
+	val := os.Getenv(key)
+	if val == "" {
+		return nil
+	}
+	return resultstore.New(val, resultstore.ConstructPath())
+}
+
+func configFromEnv() *config {
+	return &config{
+		imageSpec: sandboxImageSpec{
+			tag:    os.Getenv("OSSF_SANDBOX_IMAGE_TAG"),
+			noPull: os.Getenv("OSSF_SANDBOX_NOPULL") != "",
+		},
+		resultStores: &worker.ResultStores{
+			AnalyzedPackage: resultStoreForEnv("OSSF_MALWARE_ANALYZED_PACKAGES"),
+			DynamicAnalysis: resultStoreForEnv("OSSF_MALWARE_ANALYSIS_RESULTS"),
+			ExecutionLog:    resultStoreForEnv("OSSF_MALWARE_ANALYSIS_EXECUTION_LOGS"),
+			FileWrites:      resultStoreForEnv("OSSF_MALWARE_ANALYSIS_FILE_WRITE_RESULTS"),
+			StaticAnalysis:  resultStoreForEnv("OSSF_MALWARE_STATIC_ANALYSIS_RESULTS"),
+		},
+		subURL:               os.Getenv("OSSMALWARE_WORKER_SUBSCRIPTION"),
+		packagesBucket:       os.Getenv("OSSF_MALWARE_ANALYSIS_PACKAGES"),
+		notificationTopicURL: os.Getenv("OSSF_MALWARE_NOTIFICATION_TOPIC"),
+
+		userAgentExtra: os.Getenv("OSSF_MALWARE_USER_AGENT_EXTRA"),
+	}
+}

--- a/infra/worker/workers-set.yaml
+++ b/infra/worker/workers-set.yaml
@@ -39,6 +39,8 @@ spec:
           value: gs://ossf-malware-analysis-packages
         - name: OSSF_MALWARE_NOTIFICATION_TOPIC
           value: gcppubsub://projects/ossf-malware-analysis/topics/analysis-notify
+        - name: OSSF_MALWARE_USER_AGENT_EXTRA
+          value: "production"
         - name: OSSF_MALWARE_FEATURE_FLAGS
           value: "CodeExecution"
         securityContext:

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,40 @@
+package useragent
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const defaultUserAgentFmt = "package-analysis (github.com/ossf/package-analysis%s)"
+
+type uaRoundTripper struct {
+	parent    http.RoundTripper
+	userAgent string
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (rt *uaRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", rt.userAgent)
+	return rt.parent.RoundTrip(req)
+}
+
+// RoundTripper wraps parent with a RoundTripper that add a user-agent header
+// with the contents of ua.
+func RoundTripper(ua string, parent http.RoundTripper) http.RoundTripper {
+	return &uaRoundTripper{
+		parent:    parent,
+		userAgent: ua,
+	}
+}
+
+// DefaultRoundTripper wraps parent with a RoundTripper that adds a default
+// Package Analysis user-agent header.
+//
+// If supplied, extra information can be added to the user-agent, allowing the
+// user-agent to be customized for production environments.
+func DefaultRoundTripper(parent http.RoundTripper, extra string) http.RoundTripper {
+	if extra != "" {
+		extra = ", " + extra
+	}
+	return RoundTripper(fmt.Sprintf(defaultUserAgentFmt, extra), parent)
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,78 @@
+package useragent_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ossf/package-analysis/internal/useragent"
+)
+
+func TestRoundTripper(t *testing.T) {
+	want := "test user agent string"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("user-agent")
+		if got != want {
+			t.Errorf("User Agent = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := http.Client{
+		Transport: useragent.RoundTripper(want, http.DefaultTransport),
+	}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Get() = %v; want no error", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
+	}
+}
+
+func TestDefaultRoundTripper(t *testing.T) {
+	want := "package-analysis (github.com/ossf/package-analysis, extra)"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("user-agent")
+		if got != want {
+			t.Errorf("User Agent = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := http.Client{
+		Transport: useragent.DefaultRoundTripper(http.DefaultTransport, "extra"),
+	}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Get() = %v; want no error", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
+	}
+}
+
+func TestDefaultRoundTripper_NoExtra(t *testing.T) {
+	want := "package-analysis (github.com/ossf/package-analysis)"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("user-agent")
+		if got != want {
+			t.Errorf("User Agent = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := http.Client{
+		Transport: useragent.DefaultRoundTripper(http.DefaultTransport, ""),
+	}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Get() = %v; want no error", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Being a good API user means setting the user-agent field in outbound requests so our requests can be distinguished from others.

This change adds user-agent support.

Part of the implementation allows an "extra" component to be added to the user-agent. This is especially important as it allows our production environment to be distinguished from other runs.

To propagate this "extra" data to sandbox required some messing around with how environment variables are managed and configuration passed around in the `worker` process.

#1015