### PR TITLE
Bump GVisor to the latest release 20240212.

### DIFF
--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get upgrade -y && \
 # Install gVisor.
 RUN mkdir -m 0700 -p /etc/apt/keyrings && \
     curl -fsSL https://gvisor.dev/archive.key -o /etc/apt/keyrings/gvisor.key && \
-    echo "deb [signed-by=/etc/apt/keyrings/gvisor.key] https://storage.googleapis.com/gvisor/releases 20220425 main" > /etc/apt/sources.list.d/gvisor.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/gvisor.key] https://storage.googleapis.com/gvisor/releases 20240212 main" > /etc/apt/sources.list.d/gvisor.list && \
     apt-get update && apt-get install -y runsc
 
 COPY --from=build /src/analyze /usr/local/bin/analyze

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -331,6 +331,7 @@ func (s *podmanSandbox) startContainerCmd(ctx context.Context, logDir string) *e
 	args := []string{
 		"start",
 		"--runtime=" + runtimeBin,
+		"--runtime-flag=overlay2=none",
 		"--runtime-flag=root=" + rootDir,
 		"--runtime-flag=debug-log=" + filepath.Join(logDir, "runsc.log.%COMMAND%"),
 	}


### PR DESCRIPTION
This change includes an additional flag to disable a new (2023-03) feature that keeps filesystem changes internal to GVisor, which breaks the start/stop/restart behavior of package analysis.