### PR TITLE
golangci-lint: disable deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -62,7 +61,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - wrapcheck
 linters-settings:


### PR DESCRIPTION
Update the lint configuration to avoid errors.

This is a regression since `2024-05-03`. This blocks CI in PRs like #1050 , #1051, etc.

Alternatively, consider pinning the `version:` of `golangci-lint` used during CI: https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#version
The root cause is using a newer version of `golangci-lint` than the configuration used.


# Related

- https://github.com/golangci/golangci-lint/blob/master/CHANGELOG.md#v1580
