### PR TITLE
Update the perms to allow OSV scanning to work.

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -9,7 +9,7 @@ on:
 
 # Declare default permissions as read only.
 permissions:
-  # Only need to read contents
+  actions: read
   contents: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 permissions:
-  # Only need to read contents
+  actions: read
   contents: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write


### PR DESCRIPTION
osv-scanner-* workflows are failing because they need the `actions: read` permission.

This PR adds the permission to the workflows.