### PR TITLE
Rename deadline to the correct timeout so linting completes.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
+  timeout: 5m
 issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable.
@@ -19,12 +19,12 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - depguard
     - dogsled
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - gci
     #- gochecknoinits
     - gocognit


### PR DESCRIPTION
Also remove deprecated exportloopref and replace with copyloopvar