### PR TITLE
Update base images. Dynamicanalysis image moves to buildpack-deps 24.04

### DIFF
--- a/cmd/analyze/Dockerfile
+++ b/cmd/analyze/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download
 COPY . ./
 RUN go build -o analyze ./cmd/analyze && go build -o worker ./cmd/worker
 
-FROM ubuntu:22.04@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751
+FROM ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get upgrade -y && \

--- a/cmd/scheduler/Dockerfile
+++ b/cmd/scheduler/Dockerfile
@@ -10,7 +10,7 @@ COPY . ./
 RUN CGO_ENABLED=0 go build -o scheduler ./cmd/scheduler/main.go
 
 
-FROM gcr.io/distroless/base:nonroot@sha256:746b9dbe3065a124395d4a7698241dbd6f3febbf01b73e48f942aabd7b8e5eac
+FROM gcr.io/distroless/base:nonroot@sha256:fb282f8ed3057f71dbfe3ea0f5fa7e961415dafe4761c23948a9d4628c6166fe
 
 COPY --from=build /src/scheduler /usr/local/bin/scheduler
 

--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -4,8 +4,8 @@
 # NO_PUBKEY EB3E94ADBE1229CF [powershell]
 # NO_PUBKEY B53DC80D13EDEF05 [kubectl]
 
-# buildpack-deps 22.04 [ubuntu]
-FROM buildpack-deps@sha256:e3a9f4d68852ea0111610b75443f6eb809c28816b04088722f9a079a49cf1287 AS image
+# buildpack-deps 24.04 [ubuntu]
+FROM buildpack-deps:24.04@sha256:48a08de20b86d99a39f413b3b8521f3ca741487d2d9d7394b6d4ab8a7498cc15 AS image
 
 # All intermediate files during first-stage build are stored under /setup
 # This directory is removed before second-stage build (i.e. copying runtime files to an empty image)

--- a/sandboxes/dynamicanalysis/Dockerfile
+++ b/sandboxes/dynamicanalysis/Dockerfile
@@ -37,7 +37,6 @@ RUN curl -fsSL "https://packages.microsoft.com/config/ubuntu/22.04/packages-micr
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
 	apt-transport-https \
 	auditd \
-	awscli \
 	build-essential \
 	cmake \
 	clang \
@@ -49,10 +48,9 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
 	libpng-dev \
 	libzip-dev \
 	net-tools \
-	netcat \
+	netcat-openbsd \
 	powershell \
 	protobuf-compiler \
-	python2 \
 	sshpass \
 	sudo \
 	tcpdump \
@@ -62,11 +60,17 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
 	xxd \
 	zip
 
+
 # Configure sudo for passwordless execution
 RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Create ssh directory for root
-RUN mkdir -m 0700 /root/.ssh
+
+# install awscli v2
+# TODO: validate the integrity of the archive
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/setup/awscliv2.zip"
+RUN unzip "/setup/awscliv2.zip" -d "/setup"
+RUN /setup/aws/install
+
 
 #
 # PHP setup
@@ -102,12 +106,14 @@ WORKDIR /setup/python
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3 \
 	python3-dev \
-	python3-pip
+	python3-venv
+
+# Create a virtual environment to allow pip install to work.
+RUN python3 -m venv /app/.pyenv
 
 # Some Python packages expect certain dependencies to already be installed
 COPY pypi-packages.txt ./
-RUN pip install --require-hashes --requirement pypi-packages.txt
-
+RUN /app/.pyenv/bin/pip install --require-hashes --requirement pypi-packages.txt
 
 #
 # Rubygems setup
@@ -138,6 +144,10 @@ RUN rm -rf /setup
 FROM scratch
 COPY --from=image / /
 WORKDIR /app
+
+# Python
+# Use the Python virtual environment for all Python.
+ENV PATH="/app/.pyenv/bin:${PATH}"
 
 # Rust
 ENV PATH="/usr/local/cargo/bin:${PATH}"

--- a/sandboxes/staticanalysis/Dockerfile
+++ b/sandboxes/staticanalysis/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /src/sandboxes/staticanalysis
 # If CGO is disabled then we don't need glibc
 RUN CGO_ENABLED=0 go build -o staticanalyze staticanalyze.go
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 RUN apk add --no-cache file && \
 	apk add --no-cache nodejs && \
 	apk add --no-cache npm && \


### PR DESCRIPTION
Update the base images.

The big change is that the dynamicanalysis image `buildpack-deps` is now on 24.04, which updates some key language implementations.

This change required installing awscli v2 manually because the package no longer exists.

It also requires the use of a Python virtual env to allow the python packages to be installed. The venv is used as the default Python.