### PR TITLE
Ensure the python execute phase works when packages are not importable.

### DIFF
--- a/sandboxes/dynamicanalysis/analyze-python.py
+++ b/sandboxes/dynamicanalysis/analyze-python.py
@@ -103,9 +103,13 @@ def import_module(import_path):
 def execute_package(package):
     """Execute phase for analyzing the package."""
     for p in module_paths_to_import(package):
-        # if we're here, importing should have already worked during import phase
-        module = importlib.import_module(p)
-        execute_module(module)
+        try:
+            module = importlib.import_module(p)
+        except BaseException:
+            # We reach here when import fails. So skip this package.
+            continue
+        else:
+            execute_module(module)
 
 
 def execute_module(module):


### PR DESCRIPTION
Some recent high-profile compromises could have beeen caught if this was working.